### PR TITLE
add basic deployment based on docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 *.db
 .env
 /venv
+
+# IDE's
+.idea
+.vscode

--- a/README.md
+++ b/README.md
@@ -37,4 +37,11 @@ Visit this url:
 
 You have set up the development environment.
 
+## Run the application with docker-compose
 
+Requires docker-compose installed. [See the documentation](https://docs.docker.com/compose/install/) for instructions.
+
+```sh
+cd tools/docker
+docker-compose up --build
+```

--- a/ansible_events_ui/conf.py
+++ b/ansible_events_ui/conf.py
@@ -1,17 +1,14 @@
-import os
+from environs import Env
+
+env = Env()
+
+# Reads .env file
+env.read_env()
 
 
 class _Settings:
     def __init__(self):
-        self.SECRET = "SECRET"
-        self.load_env()
-
-    def load_env(self):
-        if os.path.exists(".env"):
-            with open(".env") as f:
-                for line in f.readlines():
-                    key, _, value = line.partition("=")
-                    setattr(self, key, value.strip())
+        self.SECRET = env.str("SECRET", default="secret")
 
 
 settings = _Settings()

--- a/ansible_events_ui/database.py
+++ b/ansible_events_ui/database.py
@@ -8,9 +8,12 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 from .models import User, metadata
+from .conf import env
 
-DATABASE_URL = "sqlite:///./test.db"
-ASYNC_DATABASE_URL = "sqlite+aiosqlite:///./test.db"
+DATABASE_URL = env.str("DATABASE_URL", default="sqlite:///./test.db")
+ASYNC_DATABASE_URL = env.str(
+    "ASYNC_DATABASE_URL", default="sqlite+aiosqlite:///./test.db"
+)
 
 database = databases.Database(DATABASE_URL)
 

--- a/ansible_events_ui/main.py
+++ b/ansible_events_ui/main.py
@@ -1,10 +1,11 @@
 import uvicorn
+from .conf import env
 
 
 def main():
     uvicorn.run(
         "ansible_events_ui.app:app",
-        host="0.0.0.0",
-        port=8080,
-        log_level="info",
+        host=env.str("HTTP_ADDR", default="0.0.0.0"),
+        port=env.int("HTTP_PORT", default=8080),
+        log_level=env.str("LOG_LEVEL", default="info"),
     )

--- a/scripts/createuser.sh
+++ b/scripts/createuser.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 USER=${1}
-read -s PASSWORD
+PASSWORD=${2}
 curl -X 'POST' \
   'http://localhost:8080/api/auth/register' \
   -H 'accept: application/json' \

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ install_requires =
     sqlalchemy ~= 1.4
     uvicorn
     websockets  # TODO(cutwater): Check if this is dependency is necessary
+    environs
 
     ansible-events
 

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,0 +1,28 @@
+# Build UI
+FROM docker.io/node:16-alpine AS ui-builder
+WORKDIR /app
+COPY . $WORKDIR
+RUN cd ui && npm install && npm run build
+
+
+# Build app
+FROM registry.access.redhat.com/ubi9/python-39
+ARG USER_ID=${USER_ID:-1001}
+ARG DEVEL_AE_LIBRARY=0
+USER 0
+
+WORKDIR $HOME
+COPY . $WORKDIR
+COPY --from=ui-builder /app/ui/dist/ ./ui/dist
+RUN mkdir sqlite
+
+RUN chown -R $USER_ID ./
+USER $USER_ID
+
+RUN pip install '.[sqlite]'
+
+RUN bash -c "if [ $DEVEL_AE_LIBRARY -ne 0 ]; then \
+    pip uninstall ansible-events && \
+    pip install git+https://github.com/benthomasson/ansible-events.git; fi"
+
+CMD ["ansible-events-ui"]

--- a/tools/docker/docker-compose.yml
+++ b/tools/docker/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.9'
+
+services:
+  app:
+    image: ansible-events-ui
+    build:
+      context: ../../
+      dockerfile: tools/docker/Dockerfile
+    ports:
+      - "8080:8080"
+    volumes:
+      - sqlite_db:/opt/app-root/src/sqlite
+    environment:
+      - DATABASE_URL=sqlite:///./sqlite/test.db
+      - ASYNC_DATABASE_URL=sqlite+aiosqlite:///./sqlite/test.db
+volumes:
+  sqlite_db: {}


### PR DESCRIPTION
Add a basic deployment with docker. 
Includes:
- environs library implementation for better management of environment variables
- customize some variables through environment variables. 
- update gitignore
- dockerfile and docker-compose file
- update "createuser" script to work in a non-interactive way. 
