### PR TITLE
 Finish migration to SQLAlchemy 2.0 API 

### DIFF
--- a/ansible_events_ui/app.py
+++ b/ansible_events_ui/app.py
@@ -11,7 +11,7 @@ from fastapi.staticfiles import StaticFiles
 from sqlalchemy import insert, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from .database import async_session_maker, database, get_async_session
+from .database import async_session_maker, get_async_session
 from .manager import activate_rulesets, inactivate_rulesets
 from .models import (
     User,
@@ -118,16 +118,6 @@ class UpdateManager:
 
 
 updatemanager = UpdateManager()
-
-
-@app.on_event("startup")
-async def startup():
-    await database.connect()
-
-
-@app.on_event("shutdown")
-async def shutdown():
-    await database.disconnect()
 
 
 @app.get("/")
@@ -269,6 +259,7 @@ async def create_activation_instance(
 
     cmd, proc = await activate_rulesets(
         id_,
+        # TODO(cutwater): Hardcoded container image link
         "quay.io/bthomass/ansible-events:latest",
         rule_set_file_row.rulesets,
         inventory_row.inventory,

--- a/ansible_events_ui/database.py
+++ b/ansible_events_ui/database.py
@@ -1,6 +1,5 @@
 from typing import AsyncGenerator
 
-import databases
 import sqlalchemy
 from fastapi import Depends
 from fastapi_users.db import SQLAlchemyUserDatabase
@@ -10,16 +9,21 @@ from sqlalchemy.orm import sessionmaker
 from .config import settings
 from .models import User, metadata
 
-database = databases.Database(settings.database_url)
-
 engine = sqlalchemy.create_engine(
     settings.database_url, connect_args={"check_same_thread": False}
 )
+# FIXME(cutwater): Do not create database schema at the module load time.
 metadata.create_all(engine)
 
+# TODO(cutwater): Do not initialize engine globally
 async_engine = create_async_engine(settings.async_database_url)
+# TODO(cutwater): After migration to SQLAlchemy 2.0 style is complete,
+#   add `future=True` argument to the `sessionmaker(...)` call.
 async_session_maker = sessionmaker(
-    async_engine, class_=AsyncSession, expire_on_commit=False
+    async_engine,
+    class_=AsyncSession,
+    expire_on_commit=False,
+    # future=True,
 )
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ packages = find:
 python_requires = >=3.6
 install_requires =
     alembic
-    databases   # TODO(cutwater): Drop databases dependency
     fastapi
     fastapi-users[sqlalchemy]
     pyyaml


### PR DESCRIPTION
* Remove `databases` initialization
* Remove package dependency.

Depends-On: #19 