### PR TITLE
point ansible-event requirement to the latest version of the main branch

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,9 +22,7 @@ install_requires =
     uvicorn
     websockets  # TODO(cutwater): Check if this is dependency is necessary
     environs
-
-    ansible-events
-
+    ansible-events @ git+https://github.com/benthomasson/ansible-events.git
 
 [options.extras_require]
 sqlite =


### PR DESCRIPTION
At this stage of development I think it's better to point the ansible-events to the latest version of the main branch. 