### PR TITLE
Update docker-compose to run migrations at startup

### DIFF
--- a/tools/docker/docker-compose.yml
+++ b/tools/docker/docker-compose.yml
@@ -6,13 +6,16 @@ services:
     build:
       context: ../../
       dockerfile: tools/docker/Dockerfile
+    command: ["/bin/bash", "-c", "alembic upgrade head && ansible-events-ui"]
     ports:
       - "8080:8080"
     environment:
       - AE_HOST=0.0.0.0
-      - AE_DATABASE_URL=postgres+asyncpg://postgres:secret@postgres/ansible_events
+      - AE_DATABASE_URL=postgresql+asyncpg://postgres:secret@postgres/ansible_events
     depends_on:
       - postgres
+    # NOTE(cutwater): Temporary workaround for a container startup readiness problem
+    restart: on-failure
 
   postgres:
     image: "docker.io/library/postgres:13"


### PR DESCRIPTION
* Fix incorrect `AE_DATABASE_URL` parameter.
* Run migrations at `app` service startup.
* Add a temporary workaround to restart a failing container if a
  database is not ready.