### PR TITLE
More versatile alembic setup

### DIFF
--- a/ansible_events_ui/db/migrations/env.py
+++ b/ansible_events_ui/db/migrations/env.py
@@ -46,13 +46,7 @@ def do_run_migrations(connection: Connection) -> None:
         context.run_migrations()
 
 
-async def run_migrations_online() -> None:
-    """Run migrations in 'online' mode.
-
-    In this scenario we need to create an Engine
-    and associate a connection with the context.
-
-    """
+async def run_async_migrations() -> None:
     connectable = AsyncEngine(
         engine_from_config(
             config.get_section(config.config_ini_section),
@@ -69,7 +63,20 @@ async def run_migrations_online() -> None:
     await connectable.dispose()
 
 
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+    """
+    connectable = config.attributes.get("connection", None)
+    if connectable is None:
+        asyncio.run(run_async_migrations())
+    else:
+        do_run_migrations(connectable)
+
+
 if context.is_offline_mode():
     run_migrations_offline()
 else:
-    asyncio.run(run_migrations_online())
+    run_migrations_online()


### PR DESCRIPTION
Add support of an existing sync engine, passed through alembic context
from the outside. This allows programmatic API use, which is required
for running migrations from within the test suite.

Refer to the Alembic documentation [1] for more details.

**Usage example:**

```python

import asyncio
from sqlalchemy.ext.asyncio import create_async_engine

from alembic import command, config

def run_upgrade(connection, cfg):
    cfg.attributes["connection"] = connection
    command.upgrade(cfg, "head")

async def run_async_upgrade():
    async_engine = create_async_engine("sqlite+aiosqlite://", echo=True)
    async with async_engine.begin() as conn:
        await conn.run_sync(run_upgrade, config.Config("alembic.ini"))

asyncio.run(run_async_upgrade())
```

**References:**

[1] https://alembic.sqlalchemy.org/en/latest/cookbook.html#programmatic-api-use-connection-sharing-with-asyncio