### PR TITLE
Remove object size, data types and the quotes on keys from the extra vars JSON view

### DIFF
--- a/ui/src/app/Activation/activation-details.tsx
+++ b/ui/src/app/Activation/activation-details.tsx
@@ -78,7 +78,10 @@ const ActivationDetails: React.FunctionComponent = ({ activation }) => {
           <Stack>
             <StackItem><Title headingLevel="h3">Variables</Title></StackItem>
             <StackItem>
-              {activationVars ? <ReactJsonView src={activationVars}/> : null}
+              {activationVars ? <ReactJsonView displayObjectSize={false}
+                                               displayDataTypes={false}
+                                               quotesOnKeys={false}
+                                               src={activationVars}/> : null}
             </StackItem>
           </Stack>
         </FlexItem>


### PR DESCRIPTION
Remove object size, data types and the quotes on keys from the extra vars JSON view. The switch for a YAML view will be added in a follow up PR.

Before: 
![Screenshot from 2022-08-05 12-39-52](https://user-images.githubusercontent.com/12769982/183122785-7ae2d33d-b504-4782-878d-07b4044509b9.png)

After:
![Screenshot from 2022-08-05 12-39-30](https://user-images.githubusercontent.com/12769982/183122808-e2e5004e-3c5e-4476-b4b5-9c8e87807a45.png)
