### PR TITLE
Rework initial database migration

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -7,7 +7,7 @@ script_location = ansible_events_ui/db/migrations
 # template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
 # Uncomment the line below if you want the files to be prepended with date and time
 # file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
-file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(rev)s_%%(slug)s
+file_template = %%(year)d%%(month).2d%%(day).2d%%(hour).2d%%(minute).2d_%%(rev)s_%%(slug)s
 
 # sys.path path, will be prepended to sys.path if present.
 # defaults to the current working directory.
@@ -20,6 +20,7 @@ prepend_sys_path = .
 # string value is passed to dateutil.tz.gettz()
 # leave blank for localtime
 # timezone =
+timezone = UTC
 
 # max length of characters to apply to the
 # "slug" field

--- a/ansible_events_ui/db/migrations/versions/202208111546_09d9de4b4624_initial.py
+++ b/ansible_events_ui/db/migrations/versions/202208111546_09d9de4b4624_initial.py
@@ -2,7 +2,7 @@
 
 Revision ID: 09d9de4b4624
 Revises:
-Create Date: 2022-08-11 15:46:47.214300
+Create Date: 2022-08-11 13:46:47.214300+00:00
 
 """
 import sqlalchemy as sa

--- a/ansible_events_ui/db/migrations/versions/2022_08_11_09d9de4b4624_initial.py
+++ b/ansible_events_ui/db/migrations/versions/2022_08_11_09d9de4b4624_initial.py
@@ -1,8 +1,8 @@
 """Initial migration.
 
-Revision ID: 42461b4ec88d
+Revision ID: 09d9de4b4624
 Revises:
-Create Date: 2022-07-25 14:44:36.885462
+Create Date: 2022-08-11 15:46:47.214300
 
 """
 import sqlalchemy as sa
@@ -10,7 +10,7 @@ from alembic import op
 from sqlalchemy.dialects.postgresql import UUID
 
 # revision identifiers, used by Alembic.
-revision = "42461b4ec88d"
+revision = "09d9de4b4624"
 down_revision = None
 branch_labels = None
 depends_on = None
@@ -19,58 +19,74 @@ depends_on = None
 def upgrade() -> None:
     op.create_table(
         "extra_var",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column(
+            "id", sa.Integer(), sa.Identity(always=True), nullable=False
+        ),
         sa.Column("name", sa.String(), nullable=True),
         sa.Column("extra_var", sa.String(), nullable=True),
-        sa.PrimaryKeyConstraint("id"),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_extra_var")),
     )
     op.create_table(
         "inventory",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column(
+            "id", sa.Integer(), sa.Identity(always=True), nullable=False
+        ),
         sa.Column("name", sa.String(), nullable=True),
         sa.Column("inventory", sa.String(), nullable=True),
-        sa.PrimaryKeyConstraint("id"),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_inventory")),
     )
     op.create_table(
         "job",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column(
+            "id", sa.Integer(), sa.Identity(always=True), nullable=False
+        ),
         sa.Column("uuid", sa.String(), nullable=True),
-        sa.PrimaryKeyConstraint("id"),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_job")),
     )
     op.create_table(
         "job_instance",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column(
+            "id", sa.Integer(), sa.Identity(always=True), nullable=False
+        ),
         sa.Column("uuid", sa.String(), nullable=True),
-        sa.PrimaryKeyConstraint("id"),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_job_instance")),
     )
     op.create_table(
         "job_instance_event",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column(
+            "id", sa.Integer(), sa.Identity(always=True), nullable=False
+        ),
         sa.Column("job_uuid", sa.String(), nullable=True),
         sa.Column("counter", sa.Integer(), nullable=True),
         sa.Column("stdout", sa.String(), nullable=True),
-        sa.PrimaryKeyConstraint("id"),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_job_instance_event")),
     )
     op.create_table(
         "playbook",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column(
+            "id", sa.Integer(), sa.Identity(always=True), nullable=False
+        ),
         sa.Column("name", sa.String(), nullable=True),
         sa.Column("playbook", sa.String(), nullable=True),
-        sa.PrimaryKeyConstraint("id"),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_playbook")),
     )
     op.create_table(
         "project",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column(
+            "id", sa.Integer(), sa.Identity(always=True), nullable=False
+        ),
         sa.Column("git_hash", sa.String(), nullable=True),
         sa.Column("url", sa.String(), nullable=True),
-        sa.PrimaryKeyConstraint("id"),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_project")),
     )
     op.create_table(
         "rule_set_file",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column(
+            "id", sa.Integer(), sa.Identity(always=True), nullable=False
+        ),
         sa.Column("name", sa.String(), nullable=True),
         sa.Column("rulesets", sa.String(), nullable=True),
-        sa.PrimaryKeyConstraint("id"),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_rule_set_file")),
     )
     op.create_table(
         "user",
@@ -80,12 +96,14 @@ def upgrade() -> None:
         sa.Column("is_superuser", sa.Boolean(), nullable=False),
         sa.Column("is_verified", sa.Boolean(), nullable=False),
         sa.Column("id", UUID(), nullable=False),
-        sa.PrimaryKeyConstraint("id"),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_user")),
     )
     op.create_index(op.f("ix_user_email"), "user", ["email"], unique=True)
     op.create_table(
         "activation",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column(
+            "id", sa.Integer(), sa.Identity(always=True), nullable=False
+        ),
         sa.Column("name", sa.String(), nullable=True),
         sa.Column("rule_set_file_id", sa.Integer(), nullable=True),
         sa.Column("inventory_id", sa.Integer(), nullable=True),
@@ -93,20 +111,25 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(
             ["extra_var_id"],
             ["extra_var.id"],
+            name=op.f("fk_activation_extra_var_id"),
         ),
         sa.ForeignKeyConstraint(
             ["inventory_id"],
             ["inventory.id"],
+            name=op.f("fk_activation_inventory_id"),
         ),
         sa.ForeignKeyConstraint(
             ["rule_set_file_id"],
             ["rule_set_file.id"],
+            name=op.f("fk_activation_rule_set_file_id"),
         ),
-        sa.PrimaryKeyConstraint("id"),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_activation")),
     )
     op.create_table(
         "activation_instance",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column(
+            "id", sa.Integer(), sa.Identity(always=True), nullable=False
+        ),
         sa.Column("name", sa.String(), nullable=True),
         sa.Column("rule_set_file_id", sa.Integer(), nullable=True),
         sa.Column("inventory_id", sa.Integer(), nullable=True),
@@ -114,103 +137,131 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(
             ["extra_var_id"],
             ["extra_var.id"],
+            name=op.f("fk_activation_instance_extra_var_id"),
         ),
         sa.ForeignKeyConstraint(
             ["inventory_id"],
             ["inventory.id"],
+            name=op.f("fk_activation_instance_inventory_id"),
         ),
         sa.ForeignKeyConstraint(
             ["rule_set_file_id"],
             ["rule_set_file.id"],
+            name=op.f("fk_activation_instance_rule_set_file_id"),
         ),
-        sa.PrimaryKeyConstraint("id"),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_activation_instance")),
     )
     op.create_table(
         "project_inventory",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column(
+            "id", sa.Integer(), sa.Identity(always=True), nullable=False
+        ),
         sa.Column("project_id", sa.Integer(), nullable=True),
         sa.Column("inventory_id", sa.Integer(), nullable=True),
         sa.ForeignKeyConstraint(
             ["inventory_id"],
             ["inventory.id"],
+            name=op.f("fk_project_inventory_inventory_id"),
         ),
         sa.ForeignKeyConstraint(
             ["project_id"],
             ["project.id"],
+            name=op.f("fk_project_inventory_project_id"),
         ),
-        sa.PrimaryKeyConstraint("id"),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_project_inventory")),
     )
     op.create_table(
         "project_playbook",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column(
+            "id", sa.Integer(), sa.Identity(always=True), nullable=False
+        ),
         sa.Column("project_id", sa.Integer(), nullable=True),
         sa.Column("playbook_id", sa.Integer(), nullable=True),
         sa.ForeignKeyConstraint(
             ["playbook_id"],
             ["playbook.id"],
+            name=op.f("fk_project_playbook_playbook_id"),
         ),
         sa.ForeignKeyConstraint(
             ["project_id"],
             ["project.id"],
+            name=op.f("fk_project_playbook_project_id"),
         ),
-        sa.PrimaryKeyConstraint("id"),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_project_playbook")),
     )
     op.create_table(
         "project_rule",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column(
+            "id", sa.Integer(), sa.Identity(always=True), nullable=False
+        ),
         sa.Column("project_id", sa.Integer(), nullable=True),
         sa.Column("rule_set_file_id", sa.Integer(), nullable=True),
         sa.ForeignKeyConstraint(
             ["project_id"],
             ["project.id"],
+            name=op.f("fk_project_rule_project_id"),
         ),
         sa.ForeignKeyConstraint(
             ["rule_set_file_id"],
             ["rule_set_file.id"],
+            name=op.f("fk_project_rule_rule_set_file_id"),
         ),
-        sa.PrimaryKeyConstraint("id"),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_project_rule")),
     )
     op.create_table(
         "project_var",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column(
+            "id", sa.Integer(), sa.Identity(always=True), nullable=False
+        ),
         sa.Column("project_id", sa.Integer(), nullable=True),
         sa.Column("vars_id", sa.Integer(), nullable=True),
         sa.ForeignKeyConstraint(
             ["project_id"],
             ["project.id"],
+            name=op.f("fk_project_var_project_id"),
         ),
         sa.ForeignKeyConstraint(
-            ["vars_id"],
-            ["extra_var.id"],
+            ["vars_id"], ["extra_var.id"], name=op.f("fk_project_var_vars_id")
         ),
-        sa.PrimaryKeyConstraint("id"),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_project_var")),
     )
     op.create_table(
         "activation_instance_job_instance",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column(
+            "id", sa.Integer(), sa.Identity(always=True), nullable=False
+        ),
         sa.Column("activation_instance_id", sa.Integer(), nullable=True),
         sa.Column("job_instance_id", sa.Integer(), nullable=True),
         sa.ForeignKeyConstraint(
             ["activation_instance_id"],
             ["activation_instance.id"],
+            name=op.f(
+                "fk_activation_instance_job_instance_activation_instance_id"
+            ),
         ),
         sa.ForeignKeyConstraint(
             ["job_instance_id"],
             ["job_instance.id"],
+            name=op.f("fk_activation_instance_job_instance_job_instance_id"),
         ),
-        sa.PrimaryKeyConstraint("id"),
+        sa.PrimaryKeyConstraint(
+            "id", name=op.f("pk_activation_instance_job_instance")
+        ),
     )
     op.create_table(
         "activation_instance_log",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column(
+            "id", sa.Integer(), sa.Identity(always=True), nullable=False
+        ),
         sa.Column("activation_instance_id", sa.Integer(), nullable=True),
         sa.Column("line_number", sa.Integer(), nullable=True),
         sa.Column("log", sa.String(), nullable=True),
         sa.ForeignKeyConstraint(
             ["activation_instance_id"],
             ["activation_instance.id"],
+            name=op.f("fk_activation_instance_log_activation_instance_id"),
         ),
-        sa.PrimaryKeyConstraint("id"),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_activation_instance_log")),
     )
 
 

--- a/ansible_events_ui/db/models.py
+++ b/ansible_events_ui/db/models.py
@@ -2,14 +2,31 @@ import sqlalchemy
 from fastapi_users.db import SQLAlchemyBaseUserTableUUID
 from sqlalchemy.ext.declarative import declarative_base
 
-metadata = sqlalchemy.MetaData()
+NAMING_CONVENTION = {
+    # Index
+    "ix": "ix_%(table_name)s_%(column_0_N_name)s",
+    # Unique constraint
+    "uq": "uq_%(table_name)s_%(column_0_N_name)s",
+    # Check
+    "ck": "ck_%(table_name)s_%(constraint_name)s",
+    # Foreign key
+    "fk": "fk_%(table_name)s_%(column_0_N_name)s",
+    # Primary key
+    "pk": "pk_%(table_name)s",
+}
+metadata = sqlalchemy.MetaData(naming_convention=NAMING_CONVENTION)
 Base = declarative_base(metadata=metadata)
 
 
 rule_set_files = sqlalchemy.Table(
     "rule_set_file",
     metadata,
-    sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
+    sqlalchemy.Column(
+        "id",
+        sqlalchemy.Integer,
+        sqlalchemy.Identity(always=True),
+        primary_key=True,
+    ),
     sqlalchemy.Column("name", sqlalchemy.String),
     sqlalchemy.Column("rulesets", sqlalchemy.String),
 )
@@ -18,7 +35,12 @@ rule_set_files = sqlalchemy.Table(
 inventories = sqlalchemy.Table(
     "inventory",
     metadata,
-    sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
+    sqlalchemy.Column(
+        "id",
+        sqlalchemy.Integer,
+        sqlalchemy.Identity(always=True),
+        primary_key=True,
+    ),
     sqlalchemy.Column("name", sqlalchemy.String),
     sqlalchemy.Column("inventory", sqlalchemy.String),
 )
@@ -27,7 +49,12 @@ inventories = sqlalchemy.Table(
 extra_vars = sqlalchemy.Table(
     "extra_var",
     metadata,
-    sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
+    sqlalchemy.Column(
+        "id",
+        sqlalchemy.Integer,
+        sqlalchemy.Identity(always=True),
+        primary_key=True,
+    ),
     sqlalchemy.Column("name", sqlalchemy.String),
     sqlalchemy.Column("extra_var", sqlalchemy.String),
 )
@@ -36,7 +63,12 @@ extra_vars = sqlalchemy.Table(
 activations = sqlalchemy.Table(
     "activation",
     metadata,
-    sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
+    sqlalchemy.Column(
+        "id",
+        sqlalchemy.Integer,
+        sqlalchemy.Identity(always=True),
+        primary_key=True,
+    ),
     sqlalchemy.Column("name", sqlalchemy.String),
     sqlalchemy.Column(
         "rule_set_file_id", sqlalchemy.ForeignKey("rule_set_file.id")
@@ -49,7 +81,12 @@ activations = sqlalchemy.Table(
 activation_instances = sqlalchemy.Table(
     "activation_instance",
     metadata,
-    sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
+    sqlalchemy.Column(
+        "id",
+        sqlalchemy.Integer,
+        sqlalchemy.Identity(always=True),
+        primary_key=True,
+    ),
     sqlalchemy.Column("name", sqlalchemy.String),
     sqlalchemy.Column(
         "rule_set_file_id", sqlalchemy.ForeignKey("rule_set_file.id")
@@ -62,7 +99,12 @@ activation_instances = sqlalchemy.Table(
 activation_instance_logs = sqlalchemy.Table(
     "activation_instance_log",
     metadata,
-    sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
+    sqlalchemy.Column(
+        "id",
+        sqlalchemy.Integer,
+        sqlalchemy.Identity(always=True),
+        primary_key=True,
+    ),
     sqlalchemy.Column(
         "activation_instance_id",
         sqlalchemy.ForeignKey("activation_instance.id"),
@@ -75,7 +117,12 @@ activation_instance_logs = sqlalchemy.Table(
 projects = sqlalchemy.Table(
     "project",
     metadata,
-    sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
+    sqlalchemy.Column(
+        "id",
+        sqlalchemy.Integer,
+        sqlalchemy.Identity(always=True),
+        primary_key=True,
+    ),
     sqlalchemy.Column("git_hash", sqlalchemy.String),
     sqlalchemy.Column("url", sqlalchemy.String),
 )
@@ -84,7 +131,12 @@ projects = sqlalchemy.Table(
 project_inventories = sqlalchemy.Table(
     "project_inventory",
     metadata,
-    sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
+    sqlalchemy.Column(
+        "id",
+        sqlalchemy.Integer,
+        sqlalchemy.Identity(always=True),
+        primary_key=True,
+    ),
     sqlalchemy.Column("project_id", sqlalchemy.ForeignKey("project.id")),
     sqlalchemy.Column("inventory_id", sqlalchemy.ForeignKey("inventory.id")),
 )
@@ -92,7 +144,12 @@ project_inventories = sqlalchemy.Table(
 project_vars = sqlalchemy.Table(
     "project_var",
     metadata,
-    sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
+    sqlalchemy.Column(
+        "id",
+        sqlalchemy.Integer,
+        sqlalchemy.Identity(always=True),
+        primary_key=True,
+    ),
     sqlalchemy.Column("project_id", sqlalchemy.ForeignKey("project.id")),
     sqlalchemy.Column("vars_id", sqlalchemy.ForeignKey("extra_var.id")),
 )
@@ -100,7 +157,12 @@ project_vars = sqlalchemy.Table(
 project_rules = sqlalchemy.Table(
     "project_rule",
     metadata,
-    sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
+    sqlalchemy.Column(
+        "id",
+        sqlalchemy.Integer,
+        sqlalchemy.Identity(always=True),
+        primary_key=True,
+    ),
     sqlalchemy.Column("project_id", sqlalchemy.ForeignKey("project.id")),
     sqlalchemy.Column(
         "rule_set_file_id", sqlalchemy.ForeignKey("rule_set_file.id")
@@ -111,21 +173,36 @@ project_rules = sqlalchemy.Table(
 jobs = sqlalchemy.Table(
     "job",
     metadata,
-    sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
+    sqlalchemy.Column(
+        "id",
+        sqlalchemy.Integer,
+        sqlalchemy.Identity(always=True),
+        primary_key=True,
+    ),
     sqlalchemy.Column("uuid", sqlalchemy.String),
 )
 
 job_instances = sqlalchemy.Table(
     "job_instance",
     metadata,
-    sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
+    sqlalchemy.Column(
+        "id",
+        sqlalchemy.Integer,
+        sqlalchemy.Identity(always=True),
+        primary_key=True,
+    ),
     sqlalchemy.Column("uuid", sqlalchemy.String),
 )
 
 activation_instance_job_instances = sqlalchemy.Table(
     "activation_instance_job_instance",
     metadata,
-    sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
+    sqlalchemy.Column(
+        "id",
+        sqlalchemy.Integer,
+        sqlalchemy.Identity(always=True),
+        primary_key=True,
+    ),
     sqlalchemy.Column(
         "activation_instance_id",
         sqlalchemy.ForeignKey("activation_instance.id"),
@@ -139,7 +216,12 @@ activation_instance_job_instances = sqlalchemy.Table(
 job_instance_events = sqlalchemy.Table(
     "job_instance_event",
     metadata,
-    sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
+    sqlalchemy.Column(
+        "id",
+        sqlalchemy.Integer,
+        sqlalchemy.Identity(always=True),
+        primary_key=True,
+    ),
     sqlalchemy.Column("job_uuid", sqlalchemy.String),
     sqlalchemy.Column("counter", sqlalchemy.Integer),
     sqlalchemy.Column("stdout", sqlalchemy.String),
@@ -149,7 +231,12 @@ job_instance_events = sqlalchemy.Table(
 playbooks = sqlalchemy.Table(
     "playbook",
     metadata,
-    sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
+    sqlalchemy.Column(
+        "id",
+        sqlalchemy.Integer,
+        sqlalchemy.Identity(always=True),
+        primary_key=True,
+    ),
     sqlalchemy.Column("name", sqlalchemy.String),
     sqlalchemy.Column("playbook", sqlalchemy.String),
 )
@@ -158,7 +245,12 @@ playbooks = sqlalchemy.Table(
 project_playbooks = sqlalchemy.Table(
     "project_playbook",
     metadata,
-    sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
+    sqlalchemy.Column(
+        "id",
+        sqlalchemy.Integer,
+        sqlalchemy.Identity(always=True),
+        primary_key=True,
+    ),
     sqlalchemy.Column("project_id", sqlalchemy.ForeignKey("project.id")),
     sqlalchemy.Column("playbook_id", sqlalchemy.ForeignKey("playbook.id")),
 )

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,3 +2,4 @@
 -r requirements_lint.txt
 
 sqlalchemy[mypy] ~= 1.4
+python-dateutil


### PR DESCRIPTION
* Introduce naming convention for database constraints (i.e. foreign keys,
  primary keys, indexes, unique constraints, checks).
* Convert existing constraints to adhere new naming convention.
* Add `GENERATED ALWAYS AS IDENTITY` constraint to the integer
  auto-increment fields.