### PR TITLE
Add rules API endpoints

### DIFF
--- a/ansible_events_ui/api/__init__.py
+++ b/ansible_events_ui/api/__init__.py
@@ -66,11 +66,13 @@ from ansible_events_ui.users import (
 )
 
 from .activation import router as activation_router
+from .rule import router as rule_router
 
 logger = logging.getLogger("ansible_events_ui")
 
 router = APIRouter()
 router.include_router(activation_router)
+router.include_router(rule_router)
 
 
 @router.websocket("/api/ws")

--- a/ansible_events_ui/api/rule.py
+++ b/ansible_events_ui/api/rule.py
@@ -1,0 +1,65 @@
+import sqlalchemy as sa
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ansible_events_ui.db import models
+from ansible_events_ui.db.dependency import get_db_session
+
+router = APIRouter()
+
+
+@router.get("/api/rules/")
+async def list_rules(db: AsyncSession = Depends(get_db_session)):
+    query = (
+        sa.select(
+            models.rules.c.id,
+            models.rules.c.name,
+            models.rules.c.action,
+            models.rulesets.c.id.label("ruleset_id"),
+            models.rulesets.c.name.label("ruleset_name"),
+        )
+        .select_from(models.rules)
+        .join(models.rulesets)
+    )
+    rows = (await db.execute(query)).all()
+
+    response = []
+    for row in rows:
+        response.append(
+            {
+                "id": row["id"],
+                "name": row["name"],
+                "action": row["action"],
+                "ruleset": {
+                    "id": row["ruleset_id"],
+                    "name": row["ruleset_name"],
+                },
+            }
+        )
+    return response
+
+
+@router.get("/api/rules/{rule_id}/")
+async def show_rule(rule_id: int, db: AsyncSession = Depends(get_db_session)):
+    query = (
+        sa.select(
+            models.rules.c.id,
+            models.rules.c.name,
+            models.rules.c.action,
+            models.rulesets.c.id.label("ruleset_id"),
+            models.rulesets.c.name.label("ruleset_name"),
+        )
+        .select_from(models.rules)
+        .join(models.rulesets)
+        .filter(models.rules.c.id == rule_id)
+    )
+    row = (await db.execute(query)).first()
+    return {
+        "id": row["id"],
+        "name": row["name"],
+        "action": row["action"],
+        "ruleset": {
+            "id": row["ruleset_id"],
+            "name": row["ruleset_name"],
+        },
+    }

--- a/tests/integration/api/test_inventory.py
+++ b/tests/integration/api/test_inventory.py
@@ -6,14 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ansible_events_ui.db import models
 
-
-@pytest.mark.asyncio
-async def test_create_rule_set_file(client: AsyncClient, db: AsyncSession):
-    response = await client.post(
-        "/api/rule_set_file/",
-        json={
-            "name": "test-ruleset-1.yml",
-            "rulesets": """
+TEST_RULESET_SIMPLE = """
 ---
 - name: Test simple
   hosts: all
@@ -26,7 +19,16 @@ async def test_create_rule_set_file(client: AsyncClient, db: AsyncSession):
       condition: event.i == 1
       action:
         debug:
-            """,
+"""
+
+
+@pytest.mark.asyncio
+async def test_create_rule_set_file(client: AsyncClient, db: AsyncSession):
+    response = await client.post(
+        "/api/rule_set_file/",
+        json={
+            "name": "test-ruleset-1.yml",
+            "rulesets": TEST_RULESET_SIMPLE,
         },
     )
     assert response.status_code == status_codes.HTTP_200_OK

--- a/tests/integration/api/test_rule.py
+++ b/tests/integration/api/test_rule.py
@@ -1,0 +1,88 @@
+import pytest
+import sqlalchemy as sa
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette import status as status_codes
+
+from ansible_events_ui.db import models
+
+TEST_RULESET_SIMPLE = """
+---
+- name: Test simple
+  hosts: all
+  sources:
+    - name: range
+      range:
+        limit: 5
+  rules:
+    - name:
+      condition: event.i == 1
+      action:
+        debug:
+"""
+
+
+async def _create_rules(db: AsyncSession):
+    (rule_set_file_id,) = (
+        await db.execute(
+            sa.insert(models.rule_set_files).values(
+                name="test-ruleset-1.yml", rulesets=TEST_RULESET_SIMPLE
+            )
+        )
+    ).inserted_primary_key
+
+    (ruleset_id,) = (
+        await db.execute(
+            sa.insert(models.rulesets).values(
+                name="Test simple",
+                rule_set_file_id=rule_set_file_id,
+            )
+        )
+    ).inserted_primary_key
+
+    (rule_id,) = (
+        await db.execute(
+            sa.insert(models.rules).values(
+                name=None, action={"debug": None}, ruleset_id=ruleset_id
+            )
+        )
+    ).inserted_primary_key
+    await db.commit()
+
+    return rule_set_file_id, ruleset_id, rule_id
+
+
+@pytest.mark.asyncio
+async def test_list_rules(client: AsyncClient, db: AsyncSession):
+    rule_set_file_id, ruleset_id, rule_id = await _create_rules(db)
+
+    response = await client.get("/api/rules/")
+    assert response.status_code == status_codes.HTTP_200_OK
+    assert response.json() == [
+        {
+            "id": rule_id,
+            "name": None,
+            "action": {"debug": None},
+            "ruleset": {
+                "id": ruleset_id,
+                "name": "Test simple",
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_show_rule(client: AsyncClient, db: AsyncSession):
+    rule_set_file_id, ruleset_id, rule_id = await _create_rules(db)
+
+    response = await client.get(f"/api/rules/{rule_id}/")
+    assert response.status_code == status_codes.HTTP_200_OK
+    assert response.json() == {
+        "id": rule_id,
+        "name": None,
+        "action": {"debug": None},
+        "ruleset": {
+            "id": ruleset_id,
+            "name": "Test simple",
+        },
+    }


### PR DESCRIPTION
Add the following API endpoints:
    
  * List rules `/api/rules/`.
  * Show rule `/api/rules/{rule_id}/`.

Show rule response example:

```
{
    "id": 18,
    "name": "print output",
    "ruleset": {
        "id": 7,
        "name": "Local Deploy Git Hook Rules"
    },
    "action": {
        "print_event": {
            "var_root": "output"
        }
    }
}

```

Depends-On: #51 
Implements: https://issues.redhat.com/browse/AAP-5039
