### PR TITLE
downgrade docker image to ubi8

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -6,7 +6,7 @@ RUN cd ui && npm install && npm run build
 
 
 # Build app
-FROM registry.access.redhat.com/ubi9/python-39
+FROM registry.access.redhat.com/ubi8/python-39
 ARG USER_ID=${USER_ID:-1001}
 ARG DEVEL_AE_LIBRARY=0
 WORKDIR $HOME


### PR DESCRIPTION
Seems that ubi9 image is not compatible with apple M1 processors.
https://access.redhat.com/solutions/6833751
https://developers.redhat.com/blog/2021/01/05/building-red-hat-enterprise-linux-9-for-the-x86-64-v2-microarchitecture-level#

As ubi8 still have support, we can use it until have a fixed ubi9 image.