### PR TITLE
AAP-5262 - API: Add POST Activation Endpoint

### DIFF
--- a/ansible_events_ui/api/__init__.py
+++ b/ansible_events_ui/api/__init__.py
@@ -40,7 +40,7 @@ from ansible_events_ui.ruleset import (
     write_job_events,
 )
 from ansible_events_ui.schemas import (
-    Activation,
+    ActivationInstance,
     ActivationLog,
     Extravars,
     Inventory,
@@ -205,7 +205,7 @@ async def create_extra_vars(
 
 @router.post("/api/activation_instance/")
 async def create_activation_instance(
-    a: Activation,
+    a: ActivationInstance,
     db: AsyncSession = Depends(get_db_session),
     db_session_factory: sqlalchemy.orm.sessionmaker = Depends(
         get_db_session_factory

--- a/ansible_events_ui/api/activation.py
+++ b/ansible_events_ui/api/activation.py
@@ -1,8 +1,47 @@
 """Activation API endpoints."""
-from fastapi import APIRouter
+import logging
+
+import sqlalchemy as sa
+from fastapi import APIRouter, Depends
+from fastapi.exceptions import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ansible_events_ui import schemas
+from ansible_events_ui.db import models
+from ansible_events_ui.db.dependency import get_db_session
+
+logger = logging.getLogger("ansible_events_ui")
 
 __all__ = ("router",)
 
 router = APIRouter()
 
-# Implement activation API here.
+
+@router.post(
+    "/api/activations/",
+    response_model=schemas.Activation,
+    operation_id="create_activation",
+)
+async def create_activation(
+    activation: schemas.Activation,
+    db: AsyncSession = Depends(get_db_session),
+):
+    query = sa.insert(models.activations).values(
+        name=activation.name,
+        description=activation.description,
+        rulebook_id=activation.rulebook_id,
+        inventory_id=activation.inventory_id,
+        execution_env_id=activation.execution_env_id,
+        restart_policy_id=activation.restart_policy_id,
+        playbook_id=activation.playbook_id,
+        activation_enabled=activation.activation_enabled,
+        extra_var_id=activation.extra_var_id,
+    )
+    try:
+        result = await db.execute(query)
+    except sa.exc.IntegrityError:
+        raise HTTPException(status_code=422, detail="Unprocessable Entity.")
+    await db.commit()
+    (id_,) = result.inserted_primary_key
+
+    return {**activation.dict(), "id": id_}

--- a/ansible_events_ui/db/migrations/versions/202208291521_57d535d96a60_update_activation_table.py
+++ b/ansible_events_ui/db/migrations/versions/202208291521_57d535d96a60_update_activation_table.py
@@ -1,0 +1,162 @@
+"""Update activation table.
+
+Revision ID: 57d535d96a60
+Revises: 0a069266ef71
+Create Date: 2022-08-29 15:21:01.782272+00:00
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "57d535d96a60"
+down_revision = "0a069266ef71"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "execution_env",
+        sa.Column(
+            "id", sa.Integer(), sa.Identity(always=True), nullable=False
+        ),
+        sa.Column("url", sa.String(), nullable=False),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_execution_env")),
+    )
+    op.create_table(
+        "restart_policy",
+        sa.Column(
+            "id", sa.Integer(), sa.Identity(always=True), nullable=False
+        ),
+        sa.Column("name", sa.String(), nullable=True),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_restart_policy")),
+    )
+    op.add_column(
+        "activation", sa.Column("description", sa.String(), nullable=True)
+    )
+    op.add_column(
+        "activation",
+        sa.Column("execution_env_id", sa.Integer(), nullable=False),
+    )
+    op.add_column(
+        "activation",
+        sa.Column("restart_policy_id", sa.Integer(), nullable=False),
+    )
+    op.add_column(
+        "activation", sa.Column("playbook_id", sa.Integer(), nullable=False)
+    )
+    op.add_column(
+        "activation",
+        sa.Column("activation_status", sa.String(), nullable=True),
+    )
+    op.add_column(
+        "activation",
+        sa.Column("activation_enabled", sa.Boolean(), nullable=False),
+    )
+    op.add_column(
+        "activation",
+        sa.Column("restarted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "activation",
+        sa.Column("restarted_count", sa.Integer(), nullable=False),
+    )
+    op.add_column(
+        "activation",
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        "activation",
+        sa.Column(
+            "modified_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            onupdate=sa.text("now()"),
+            nullable=False,
+        ),
+    )
+    op.alter_column(
+        "activation", "name", existing_type=sa.VARCHAR(), nullable=False
+    )
+    op.alter_column(
+        "activation", "rulebook_id", existing_type=sa.INTEGER(), nullable=False
+    )
+    op.alter_column(
+        "activation",
+        "inventory_id",
+        existing_type=sa.INTEGER(),
+        nullable=False,
+    )
+    op.alter_column(
+        "activation",
+        "extra_var_id",
+        existing_type=sa.INTEGER(),
+        nullable=False,
+    )
+    op.create_foreign_key(
+        op.f("fk_activation_restart_policy_id"),
+        "activation",
+        "restart_policy",
+        ["restart_policy_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        op.f("fk_activation_execution_env_id"),
+        "activation",
+        "execution_env",
+        ["execution_env_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        op.f("fk_activation_playbook_id"),
+        "activation",
+        "playbook",
+        ["playbook_id"],
+        ["id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        op.f("fk_activation_playbook_id"), "activation", type_="foreignkey"
+    )
+    op.drop_constraint(
+        op.f("fk_activation_execution_env_id"),
+        "activation",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        op.f("fk_activation_restart_policy_id"),
+        "activation",
+        type_="foreignkey",
+    )
+    op.alter_column(
+        "activation", "extra_var_id", existing_type=sa.INTEGER(), nullable=True
+    )
+    op.alter_column(
+        "activation", "inventory_id", existing_type=sa.INTEGER(), nullable=True
+    )
+    op.alter_column(
+        "activation", "rulebook_id", existing_type=sa.INTEGER(), nullable=True
+    )
+    op.alter_column(
+        "activation", "name", existing_type=sa.VARCHAR(), nullable=True
+    )
+    op.drop_column("activation", "modified_at")
+    op.drop_column("activation", "created_at")
+    op.drop_column("activation", "restarted_count")
+    op.drop_column("activation", "restarted_at")
+    op.drop_column("activation", "activation_enabled")
+    op.drop_column("activation", "activation_status")
+    op.drop_column("activation", "playbook_id")
+    op.drop_column("activation", "restart_policy_id")
+    op.drop_column("activation", "execution_env_id")
+    op.drop_column("activation", "description")
+    op.drop_table("restart_policy")
+    op.drop_table("execution_env")

--- a/ansible_events_ui/db/models.py
+++ b/ansible_events_ui/db/models.py
@@ -2,6 +2,7 @@ import sqlalchemy
 from fastapi_users.db import SQLAlchemyBaseUserTableUUID
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.sql import func
 
 NAMING_CONVENTION = {
     # Index
@@ -118,12 +119,78 @@ activations = sqlalchemy.Table(
         sqlalchemy.Identity(always=True),
         primary_key=True,
     ),
-    sqlalchemy.Column("name", sqlalchemy.String),
-    sqlalchemy.Column("rulebook_id", sqlalchemy.ForeignKey("rulebook.id")),
-    sqlalchemy.Column("inventory_id", sqlalchemy.ForeignKey("inventory.id")),
-    sqlalchemy.Column("extra_var_id", sqlalchemy.ForeignKey("extra_var.id")),
+    sqlalchemy.Column("name", sqlalchemy.String, nullable=False),
+    sqlalchemy.Column("description", sqlalchemy.String),
+    sqlalchemy.Column(
+        "execution_env_id",
+        sqlalchemy.ForeignKey("execution_env.id"),
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "rulebook_id",
+        sqlalchemy.ForeignKey("rulebook.id"),
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "inventory_id", sqlalchemy.ForeignKey("inventory.id"), nullable=False
+    ),
+    sqlalchemy.Column(
+        "extra_var_id", sqlalchemy.ForeignKey("extra_var.id"), nullable=False
+    ),
+    sqlalchemy.Column(
+        "restart_policy_id",
+        sqlalchemy.ForeignKey("restart_policy.id"),
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "playbook_id", sqlalchemy.ForeignKey("playbook.id"), nullable=False
+    ),
+    sqlalchemy.Column("activation_status", sqlalchemy.String),
+    sqlalchemy.Column(
+        "activation_enabled", sqlalchemy.Boolean, nullable=False
+    ),
+    sqlalchemy.Column("restarted_at", sqlalchemy.DateTime(timezone=True)),
+    sqlalchemy.Column(
+        "restarted_count", sqlalchemy.Integer, nullable=False, default=0
+    ),
+    sqlalchemy.Column(
+        "created_at",
+        sqlalchemy.DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    ),
+    sqlalchemy.Column(
+        "modified_at",
+        sqlalchemy.DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    ),
 )
 
+execution_envs = sqlalchemy.Table(
+    "execution_env",
+    metadata,
+    sqlalchemy.Column(
+        "id",
+        sqlalchemy.Integer,
+        sqlalchemy.Identity(always=True),
+        primary_key=True,
+    ),
+    sqlalchemy.Column("url", sqlalchemy.String, nullable=False),
+)
+
+restart_policies = sqlalchemy.Table(
+    "restart_policy",
+    metadata,
+    sqlalchemy.Column(
+        "id",
+        sqlalchemy.Integer,
+        sqlalchemy.Identity(always=True),
+        primary_key=True,
+    ),
+    sqlalchemy.Column("name", sqlalchemy.String),
+)
 
 activation_instances = sqlalchemy.Table(
     "activation_instance",

--- a/ansible_events_ui/schemas.py
+++ b/ansible_events_ui/schemas.py
@@ -57,8 +57,13 @@ class Extravars(BaseModel):
 class Activation(BaseModel):
     id: Optional[int]
     name: StrictStr
+    description: Optional[StrictStr]
+    execution_env_id: int
     rulebook_id: int
     inventory_id: int
+    restart_policy_id: int
+    playbook_id: int
+    activation_enabled: bool
     extra_var_id: int
 
 

--- a/tests/integration/api/test_activation.py
+++ b/tests/integration/api/test_activation.py
@@ -1,1 +1,104 @@
-# Implement tests for activation API here.
+import pytest
+import sqlalchemy as sa
+from fastapi import status as status_codes
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ansible_events_ui.db import models
+
+TEST_ACTIVATION = {
+    "id": 1,
+    "name": "test-activation",
+    "rulebook_id": 1,
+    "inventory_id": 1,
+    "extra_var_id": 1,
+    "description": "demo activation",
+    "execution_env_id": 1,
+    "restart_policy_id": 1,
+    "playbook_id": 1,
+    "activation_enabled": True,
+}
+
+TEST_EXTRA_VAR = """
+---
+collections:
+  - community.general
+  - benthomasson.eda  # 1.3.0
+"""
+
+TEST_INVENTORY = """
+---
+all:
+    hosts:
+        localhost:
+            ansible_connection: local
+            ansible_python_interpreter: /usr/bin/python3
+"""
+
+TEST_RULEBOOK = """
+---
+- name: hello
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - debug:
+        msg: hello
+"""
+
+TEST_PLAYBOOK = TEST_RULEBOOK
+
+
+@pytest.mark.asyncio
+async def test_create_activation(client: AsyncClient, db: AsyncSession):
+    query = sa.insert(models.extra_vars).values(
+        name="vars.yml", extra_var=TEST_EXTRA_VAR
+    )
+    await db.execute(query)
+    query = sa.insert(models.inventories).values(
+        name="inventory.yml", inventory=TEST_INVENTORY
+    )
+    await db.execute(query)
+    query = sa.insert(models.rulebooks).values(
+        name="ruleset.yml", rulesets=TEST_RULEBOOK
+    )
+    await db.execute(query)
+    query = sa.insert(models.playbooks).values(
+        name="hello.yml", playbook=TEST_PLAYBOOK
+    )
+    await db.execute(query)
+    query = sa.insert(models.restart_policies).values(name="test_restart")
+    await db.execute(query)
+    query = sa.insert(models.execution_envs).values(
+        url="quay.io/bthomass/ansible-events:latest"
+    )
+    await db.execute(query)
+
+    response = await client.post(
+        "/api/activations/",
+        json=TEST_ACTIVATION,
+    )
+    assert response.status_code == status_codes.HTTP_200_OK
+    data = response.json()
+    assert "id" in data
+    assert data["name"] == TEST_ACTIVATION["name"]
+
+    activations = (await db.execute(sa.select(models.activations))).all()
+    assert len(activations) == 1
+    activation = activations[0]
+    assert activation["id"] == data["id"]
+    assert activation["name"] == TEST_ACTIVATION["name"]
+    assert (
+        activation["activation_enabled"]
+        == TEST_ACTIVATION["activation_enabled"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_activation_bad_entity(
+    client: AsyncClient, db: AsyncSession
+):
+    response = await client.post(
+        "/api/activations/",
+        json=TEST_ACTIVATION,
+    )
+    assert response.status_code == status_codes.HTTP_422_UNPROCESSABLE_ENTITY


### PR DESCRIPTION
Add POST Activation Endpoint

Add a new API endpoint `/api/activations/` to create new activations.

Test:
 - Send a POST request to `/api/activations/` with the following request body:
 ```
{
    "name": "demo",
    "rulebook_id": 1,
    "inventory_id": 1,
    "extra_var_id": 1,
    "description": "demo activation",
    "execution_env_id": 1,
    "restart_policy_id": 1,
    "playbook_id": 1,
    "activation_enabled": true,
}
```
NOTE: The code assumes that you already have inventory, extra vars, restart policy, playbook and execution environment created.

Resolves: [AAP-5262](https://issues.redhat.com/browse/AAP-5262)
Also see: [AAP-5226](https://issues.redhat.com/browse/AAP-5226), [AAP-5227](https://issues.redhat.com/browse/AAP-5227)