### PR TITLE
Use module imports for schemas and models

### DIFF
--- a/ansible_events_ui/api/__init__.py
+++ b/ansible_events_ui/api/__init__.py
@@ -10,22 +10,11 @@ from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
 from sqlalchemy import insert, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from ansible_events_ui import schemas
+from ansible_events_ui.db import models
 from ansible_events_ui.db.dependency import (
     get_db_session,
     get_db_session_factory,
-)
-from ansible_events_ui.db.models import (
-    User,
-    activation_instance_job_instances,
-    activation_instance_logs,
-    activation_instances,
-    extra_vars,
-    inventories,
-    job_instance_events,
-    job_instances,
-    playbooks,
-    projects,
-    rulebooks,
 )
 from ansible_events_ui.managers import taskmanager, updatemanager
 from ansible_events_ui.project import (
@@ -38,18 +27,6 @@ from ansible_events_ui.ruleset import (
     inactivate_rulesets,
     run_job,
     write_job_events,
-)
-from ansible_events_ui.schemas import (
-    ActivationInstance,
-    ActivationLog,
-    Extravars,
-    Inventory,
-    JobInstance,
-    Project,
-    Rulebook,
-    UserCreate,
-    UserRead,
-    UserUpdate,
 )
 from ansible_events_ui.users import (
     auth_backend,
@@ -80,12 +57,16 @@ async def websocket_endpoint2(
             # TODO(cutwater): Some data validation is needed
             data_type = data.get("type")
             if data_type == "Job":
-                query = insert(job_instances).values(uuid=data.get("job_id"))
+                query = insert(models.job_instances).values(
+                    uuid=data.get("job_id")
+                )
                 result = await db.execute(query)
                 (job_instance_id,) = result.inserted_primary_key
 
                 activation_instance_id = int(data.get("ansible_events_id"))
-                query = insert(activation_instance_job_instances).values(
+                query = insert(
+                    models.activation_instance_job_instances
+                ).values(
                     job_instance_id=job_instance_id,
                     activation_instance_id=activation_instance_id,
                 )
@@ -102,8 +83,8 @@ async def websocket_endpoint2(
             elif data_type == "AnsibleEvent":
                 event_data = data.get("event", {})
                 if event_data.get("stdout"):
-                    query = select(job_instances).where(
-                        job_instances.c.uuid == event_data.get("job_id")
+                    query = select(models.job_instances).where(
+                        models.job_instances.c.uuid == event_data.get("job_id")
                     )
                     result = await db.execute(query)
                     job_instance_id = result.first().job_instance_id
@@ -115,7 +96,7 @@ async def websocket_endpoint2(
                         ),
                     )
 
-                query = insert(job_instance_events).values(
+                query = insert(models.job_instance_events).values(
                     job_uuid=event_data.get("job_id"),
                     counter=event_data.get("counter"),
                     stdout=event_data.get("stdout"),
@@ -166,9 +147,9 @@ async def websocket_job_endpoint(websocket: WebSocket, job_instance_id):
 
 @router.post("/api/rulebooks/")
 async def create_rulebook(
-    rulebook: Rulebook, db: AsyncSession = Depends(get_db_session)
+    rulebook: schemas.Rulebook, db: AsyncSession = Depends(get_db_session)
 ):
-    query = insert(rulebooks).values(
+    query = insert(models.rulebooks).values(
         name=rulebook.name, rulesets=rulebook.rulesets
     )
     result = await db.execute(query)
@@ -183,9 +164,11 @@ async def create_rulebook(
 
 @router.post("/api/inventory/")
 async def create_inventory(
-    i: Inventory, db: AsyncSession = Depends(get_db_session)
+    i: schemas.Inventory, db: AsyncSession = Depends(get_db_session)
 ):
-    query = insert(inventories).values(name=i.name, inventory=i.inventory)
+    query = insert(models.inventories).values(
+        name=i.name, inventory=i.inventory
+    )
     result = await db.execute(query)
     await db.commit()
     (id_,) = result.inserted_primary_key
@@ -194,9 +177,11 @@ async def create_inventory(
 
 @router.post("/api/extra_vars/")
 async def create_extra_vars(
-    e: Extravars, db: AsyncSession = Depends(get_db_session)
+    e: schemas.Extravars, db: AsyncSession = Depends(get_db_session)
 ):
-    query = insert(extra_vars).values(name=e.name, extra_var=e.extra_var)
+    query = insert(models.extra_vars).values(
+        name=e.name, extra_var=e.extra_var
+    )
     result = await db.execute(query)
     await db.commit()
     (id_,) = result.inserted_primary_key
@@ -205,22 +190,28 @@ async def create_extra_vars(
 
 @router.post("/api/activation_instance/")
 async def create_activation_instance(
-    a: ActivationInstance,
+    a: schemas.ActivationInstance,
     db: AsyncSession = Depends(get_db_session),
     db_session_factory: sqlalchemy.orm.sessionmaker = Depends(
         get_db_session_factory
     ),
 ):
-    query = select(rulebooks).where(rulebooks.c.id == a.rulebook_id)
+    query = select(models.rulebooks).where(
+        models.rulebooks.c.id == a.rulebook_id
+    )
     rulebook_row = (await db.execute(query)).first()
 
-    query = select(inventories).where(inventories.c.id == a.inventory_id)
+    query = select(models.inventories).where(
+        models.inventories.c.id == a.inventory_id
+    )
     inventory_row = (await db.execute(query)).first()
 
-    query = select(extra_vars).where(extra_vars.c.id == a.extra_var_id)
+    query = select(models.extra_vars).where(
+        models.extra_vars.c.id == a.extra_var_id
+    )
     extra_var_row = (await db.execute(query)).first()
 
-    query = insert(activation_instances).values(
+    query = insert(models.activation_instances).values(
         name=a.name,
         rulebook_id=a.rulebook_id,
         inventory_id=a.inventory_id,
@@ -271,7 +262,7 @@ async def read_output(proc, activation_instance_id, db_session_factory):
                 f"/activation_instance/{activation_instance_id}",
                 json.dumps(["Stdout", {"stdout": line}]),
             )
-            query = insert(activation_instance_logs).values(
+            query = insert(models.activation_instance_logs).values(
                 line_number=line_number,
                 log=line,
                 activation_instance_id=activation_instance_id,
@@ -282,18 +273,19 @@ async def read_output(proc, activation_instance_id, db_session_factory):
 
 
 @router.get(
-    "/api/activation_instance_logs/", response_model=List[ActivationLog]
+    "/api/activation_instance_logs/",
+    response_model=List[schemas.ActivationLog],
 )
 async def list_activation_instance_logs(
     activation_instance_id: int, db: AsyncSession = Depends(get_db_session)
 ):
     query = (
-        select(activation_instance_logs)
+        select(models.activation_instance_logs)
         .where(
-            activation_instance_logs.c.activation_instance_id
+            models.activation_instance_logs.c.activation_instance_id
             == activation_instance_id
         )
-        .order_by(activation_instance_logs.c.id)
+        .order_by(models.activation_instance_logs.c.id)
     )
     result = await db.execute(query)
     return result.all()
@@ -314,11 +306,11 @@ async def list_tasks():
 
 @router.post("/api/project/")
 async def create_project(
-    p: Project, db: AsyncSession = Depends(get_db_session)
+    p: schemas.Project, db: AsyncSession = Depends(get_db_session)
 ):
     found_hash, tempdir = await clone_project(p.url, p.git_hash)
     p.git_hash = found_hash
-    query = insert(projects).values(url=p.url, git_hash=p.git_hash)
+    query = insert(models.projects).values(url=p.url, git_hash=p.git_hash)
     result = await db.execute(query)
     (project_id,) = result.inserted_primary_key
     await sync_project(project_id, tempdir, db)
@@ -331,44 +323,44 @@ async def read_project(
     project_id: int, db: AsyncSession = Depends(get_db_session)
 ):
     # FIXME(cutwater): Return HTTP 404 if project doesn't exist
-    query = select(projects).where(projects.c.id == project_id)
+    query = select(models.projects).where(models.projects.c.id == project_id)
     project = (await db.execute(query)).first()
 
     response = dict(project)
 
     response["rulesets"] = (
         await db.execute(
-            select(rulebooks.c.id, rulebooks.c.name)
-            .select_from(rulebooks)
-            .join(projects)
-            .where(projects.c.id == project_id)
+            select(models.rulebooks.c.id, models.rulebooks.c.name)
+            .select_from(models.rulebooks)
+            .join(models.projects)
+            .where(models.projects.c.id == project_id)
         )
     ).all()
 
     response["inventories"] = (
         await db.execute(
-            select(inventories.c.id, inventories.c.name)
-            .select_from(inventories)
-            .join(projects)
-            .where(projects.c.id == project_id)
+            select(models.inventories.c.id, models.inventories.c.name)
+            .select_from(models.inventories)
+            .join(models.projects)
+            .where(models.projects.c.id == project_id)
         )
     ).all()
 
     response["vars"] = (
         await db.execute(
-            select(extra_vars.c.id, extra_vars.c.name)
-            .select_from(extra_vars)
-            .join(projects)
-            .where(projects.c.id == project_id)
+            select(models.extra_vars.c.id, models.extra_vars.c.name)
+            .select_from(models.extra_vars)
+            .join(models.projects)
+            .where(models.projects.c.id == project_id)
         )
     ).all()
 
     response["playbooks"] = (
         await db.execute(
-            select(playbooks.c.id, playbooks.c.name)
-            .select_from(playbooks)
-            .join(projects)
-            .where(projects.c.id == project_id)
+            select(models.playbooks.c.id, models.playbooks.c.name)
+            .select_from(models.playbooks)
+            .join(models.projects)
+            .where(models.projects.c.id == project_id)
         )
     ).all()
 
@@ -377,14 +369,14 @@ async def read_project(
 
 @router.get("/api/projects/")
 async def list_projects(db: AsyncSession = Depends(get_db_session)):
-    query = select(projects)
+    query = select(models.projects)
     result = await db.execute(query)
     return result.all()
 
 
 @router.get("/api/playbooks/")
 async def list_playbooks(db: AsyncSession = Depends(get_db_session)):
-    query = select(playbooks)
+    query = select(models.playbooks)
     result = await db.execute(query)
     return result.all()
 
@@ -393,14 +385,16 @@ async def list_playbooks(db: AsyncSession = Depends(get_db_session)):
 async def read_playbook(
     playbook_id: int, db: AsyncSession = Depends(get_db_session)
 ):
-    query = select(playbooks).where(playbooks.c.id == playbook_id)
+    query = select(models.playbooks).where(
+        models.playbooks.c.id == playbook_id
+    )
     result = await db.execute(query)
     return result.first()
 
 
 @router.get("/api/inventories/")
 async def list_inventories(db: AsyncSession = Depends(get_db_session)):
-    query = select(inventories)
+    query = select(models.inventories)
     result = await db.execute(query)
     return result.all()
 
@@ -410,14 +404,16 @@ async def read_inventory(
     inventory_id: int, db: AsyncSession = Depends(get_db_session)
 ):
     # FIXME(cutwater): Return HTTP 404 if inventory doesn't exist
-    query = select(inventories).where(inventories.c.id == inventory_id)
+    query = select(models.inventories).where(
+        models.inventories.c.id == inventory_id
+    )
     result = await db.execute(query)
     return result.first()
 
 
 @router.get("/api/rulebooks/")
 async def list_rulebooks(db: AsyncSession = Depends(get_db_session)):
-    query = select(rulebooks)
+    query = select(models.rulebooks)
     result = await db.execute(query)
     return result.all()
 
@@ -426,7 +422,9 @@ async def list_rulebooks(db: AsyncSession = Depends(get_db_session)):
 async def read_rulebook(
     rulebook_id: int, db: AsyncSession = Depends(get_db_session)
 ):
-    query = select(rulebooks).where(rulebooks.c.id == rulebook_id)
+    query = select(models.rulebooks).where(
+        models.rulebooks.c.id == rulebook_id
+    )
     result = await db.execute(query)
     return result.first()
 
@@ -435,7 +433,9 @@ async def read_rulebook(
 async def read_rulebook_json(
     rulebook_id: int, db: AsyncSession = Depends(get_db_session)
 ):
-    query = select(rulebooks).where(rulebooks.c.id == rulebook_id)
+    query = select(models.rulebooks).where(
+        models.rulebooks.c.id == rulebook_id
+    )
     result = await db.execute(query)
 
     response = dict(result.first())
@@ -445,7 +445,7 @@ async def read_rulebook_json(
 
 @router.get("/api/extra_vars/")
 async def list_extra_vars(db: AsyncSession = Depends(get_db_session)):
-    query = select(extra_vars)
+    query = select(models.extra_vars)
     result = await db.execute(query)
     return result.all()
 
@@ -454,7 +454,9 @@ async def list_extra_vars(db: AsyncSession = Depends(get_db_session)):
 async def read_extravar(
     extra_var_id: int, db: AsyncSession = Depends(get_db_session)
 ):
-    query = select(extra_vars).where(extra_vars.c.id == extra_var_id)
+    query = select(models.extra_vars).where(
+        models.extra_vars.c.id == extra_var_id
+    )
     result = await db.execute(query)
     return result.first()
 
@@ -463,7 +465,7 @@ async def read_extravar(
 async def list_activation_instances(
     db: AsyncSession = Depends(get_db_session),
 ):
-    query = select(activation_instances)
+    query = select(models.activation_instances)
     result = await db.execute(query)
     return result.all()
 
@@ -474,21 +476,21 @@ async def read_activation_instance(
 ):
     query = (
         select(
-            activation_instances.c.id,
-            activation_instances.c.name,
-            rulebooks.c.id.label("ruleset_id"),
-            rulebooks.c.name.label("ruleset_name"),
-            inventories.c.id.label("inventory_id"),
-            inventories.c.name.label("inventory_name"),
-            extra_vars.c.id.label("extra_var_id"),
-            extra_vars.c.name.label("extra_vars_name"),
+            models.activation_instances.c.id,
+            models.activation_instances.c.name,
+            models.rulebooks.c.id.label("ruleset_id"),
+            models.rulebooks.c.name.label("ruleset_name"),
+            models.inventories.c.id.label("inventory_id"),
+            models.inventories.c.name.label("inventory_name"),
+            models.extra_vars.c.id.label("extra_var_id"),
+            models.extra_vars.c.name.label("extra_vars_name"),
         )
         .select_from(
-            activation_instances.join(rulebooks)
-            .join(inventories)
-            .join(extra_vars)
+            models.activation_instances.join(models.rulebooks)
+            .join(models.inventories)
+            .join(models.extra_vars)
         )
-        .where(activation_instances.c.id == activation_instance_id)
+        .where(models.activation_instances.c.id == activation_instance_id)
     )
     result = await db.execute(query)
     return result.first()
@@ -496,28 +498,34 @@ async def read_activation_instance(
 
 @router.get("/api/job_instances/")
 async def list_job_instances(db: AsyncSession = Depends(get_db_session)):
-    query = select(job_instances)
+    query = select(models.job_instances)
     result = await db.execute(query)
     return result.all()
 
 
 @router.post("/api/job_instance/")
 async def create_job_instance(
-    j: JobInstance, db: AsyncSession = Depends(get_db_session)
+    j: schemas.JobInstance, db: AsyncSession = Depends(get_db_session)
 ):
 
-    query = select(playbooks).where(playbooks.c.id == j.playbook_id)
+    query = select(models.playbooks).where(
+        models.playbooks.c.id == j.playbook_id
+    )
     playbook_row = (await db.execute(query)).first()
 
-    query = select(inventories).where(inventories.c.id == j.inventory_id)
+    query = select(models.inventories).where(
+        models.inventories.c.id == j.inventory_id
+    )
     inventory_row = (await db.execute(query)).first()
 
-    query = select(extra_vars).where(extra_vars.c.id == j.extra_var_id)
+    query = select(models.extra_vars).where(
+        models.extra_vars.c.id == j.extra_var_id
+    )
     extra_var_row = (await db.execute(query)).first()
 
     job_uuid = str(uuid.uuid4())
 
-    query = insert(job_instances).values(uuid=job_uuid)
+    query = insert(models.job_instances).values(uuid=job_uuid)
     result = await db.execute(query)
     await db.commit()
     (job_instance_id,) = result.inserted_primary_key
@@ -548,7 +556,9 @@ async def create_job_instance(
 async def read_job_instance(
     job_instance_id: int, db: AsyncSession = Depends(get_db_session)
 ):
-    query = select(job_instances).where(job_instances.c.id == job_instance_id)
+    query = select(models.job_instances).where(
+        models.job_instances.c.id == job_instance_id
+    )
     result = await db.execute(query)
     return result.first()
 
@@ -557,13 +567,15 @@ async def read_job_instance(
 async def read_job_instance_events(
     job_instance_id: int, db: AsyncSession = Depends(get_db_session)
 ):
-    query = select(job_instances).where(job_instances.c.id == job_instance_id)
+    query = select(models.job_instances).where(
+        models.job_instances.c.id == job_instance_id
+    )
     job = (await db.execute(query)).first()
 
     query = (
-        select(job_instance_events)
-        .where(job_instance_events.c.job_uuid == job.uuid)
-        .order_by(job_instance_events.c.counter)
+        select(models.job_instance_events)
+        .where(models.job_instance_events.c.job_uuid == job.uuid)
+        .order_by(models.job_instance_events.c.counter)
     )
     return (await db.execute(query)).all()
 
@@ -572,8 +584,8 @@ async def read_job_instance_events(
 async def read_activation_instance_job_instances(
     activation_instance_id: int, db: AsyncSession = Depends(get_db_session)
 ):
-    query = select(activation_instance_job_instances).where(
-        activation_instance_job_instances.c.activation_instance_id
+    query = select(models.activation_instance_job_instances).where(
+        models.activation_instance_job_instances.c.activation_instance_id
         == activation_instance_id
     )
     result = await db.execute(query)
@@ -589,7 +601,7 @@ router.include_router(
     tags=["auth"],
 )
 router.include_router(
-    fastapi_users.get_register_router(UserRead, UserCreate),
+    fastapi_users.get_register_router(schemas.UserRead, schemas.UserCreate),
     prefix="/api/auth",
     tags=["auth"],
 )
@@ -599,17 +611,19 @@ router.include_router(
     tags=["auth"],
 )
 router.include_router(
-    fastapi_users.get_verify_router(UserRead),
+    fastapi_users.get_verify_router(schemas.UserRead),
     prefix="/api/auth",
     tags=["auth"],
 )
 router.include_router(
-    fastapi_users.get_users_router(UserRead, UserUpdate),
+    fastapi_users.get_users_router(schemas.UserRead, schemas.UserUpdate),
     prefix="/api/users",
     tags=["users"],
 )
 
 
 @router.get("/api/authenticated-route")
-async def authenticated_route(user: User = Depends(current_active_user)):
+async def authenticated_route(
+    user: models.User = Depends(current_active_user),
+):
     return {"message": f"Hello {user.email}!"}


### PR DESCRIPTION
The schema and models modules may and eventually will contain
similarly named classes (e.g. `schemas.Project` and `models.Project`).

Therefore to prevent name conflicts it is preferrable to use module
imports instead of importing names from module.

This patch updates such imports in the `api` package.