### PR TITLE
add GH action for testing app and docker-compose

### DIFF
--- a/.github/workflows/test-docker-deployment.yml
+++ b/.github/workflows/test-docker-deployment.yml
@@ -1,0 +1,21 @@
+name: Test docker deployment
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  test-docker-deployment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Deploy docker-compose and test it
+        working-directory: tools/docker
+        run: |
+          docker-compose up -d --build
+          curl -q http://localhost:8080/ping
+          curl -q http://localhost:8080/eda

--- a/tools/docker/docker-compose.yml
+++ b/tools/docker/docker-compose.yml
@@ -6,7 +6,12 @@ services:
     build:
       context: ../../
       dockerfile: tools/docker/Dockerfile
-    command: ["/bin/bash", "-c", "alembic upgrade head && ansible-events-ui"]
+    command:
+      [
+        "/bin/bash",
+        "-c",
+        "alembic upgrade head && ansible-events-ui"
+      ]
     ports:
       - "8080:8080"
     environment:
@@ -14,6 +19,18 @@ services:
       - AE_DATABASE_URL=postgresql+asyncpg://postgres:secret@postgres/ansible_events
     depends_on:
       postgres:
+        condition: service_healthy
+    healthcheck:
+      test: curl -q http://localhost:8080/ping
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  wait_for_app:
+    image: ansible-events-ui
+    command: echo app running!
+    depends_on:
+      app:
         condition: service_healthy
 
   postgres:


### PR DESCRIPTION
This action allow us to run a sanity test for the app and the docker-compose. 
Also include a new pod in the compose definition, docker-compose doesn't honor the healthcheck at startup time, only when other pod requires it. Added a new pod to ensure that the app is up. 