### PR TITLE
Fix ui server for react internal routing

### DIFF
--- a/tests/integration/test_root_handlers.py
+++ b/tests/integration/test_root_handlers.py
@@ -7,7 +7,7 @@ from httpx import AsyncClient
 async def test_root(client: AsyncClient):
     response = await client.get("/", follow_redirects=False)
     assert response.status_code == status_codes.HTTP_307_TEMPORARY_REDIRECT
-    assert response.headers["Location"] == "/eda"
+    assert response.headers["Location"] == "/eda/"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR fixes the internal routing of react. Now, all UI links works and you can open a link in a new tab. 
Also fixes the redirect to save one unnecessary redirect from `/eda` to `/eda/`