### PR TITLE
Add GET/PATCH Activation Endpoints

### DIFF
--- a/ansible_events_ui/api/activation.py
+++ b/ansible_events_ui/api/activation.py
@@ -19,11 +19,11 @@ router = APIRouter()
 
 @router.post(
     "/api/activations/",
-    response_model=schemas.Activation,
+    response_model=schemas.ActivationBaseRead,
     operation_id="create_activation",
 )
 async def create_activation(
-    activation: schemas.Activation,
+    activation: schemas.ActivationCreate,
     db: AsyncSession = Depends(get_db_session),
 ):
     query = sa.insert(models.activations).values(
@@ -45,3 +45,93 @@ async def create_activation(
     (id_,) = result.inserted_primary_key
 
     return {**activation.dict(), "id": id_}
+
+
+@router.get(
+    "/api/activation/{activation_id}",
+    response_model=schemas.ActivationRead,
+    operation_id="show_activation",
+)
+async def read_activation(
+    activation_id: int, db: AsyncSession = Depends(get_db_session)
+):
+    query = (
+        sa.select(
+            models.activations.c.id,
+            models.activations.c.name,
+            models.activations.c.description,
+            models.activations.c.activation_enabled,
+            models.activations.c.activation_status,
+            models.activations.c.restarted_at,
+            models.activations.c.restarted_count,
+            models.activations.c.created_at,
+            models.activations.c.modified_at,
+            models.rulebooks.c.id.label("rulebook_id"),
+            models.rulebooks.c.name.label("rulebook_name"),
+            models.inventories.c.id.label("inventory_id"),
+            models.inventories.c.name.label("inventory_name"),
+            models.extra_vars.c.id.label("extra_var_id"),
+            models.extra_vars.c.name.label("extra_var_name"),
+            models.playbooks.c.id.label("playbook_id"),
+            models.playbooks.c.name.label("playbook_name"),
+            models.restart_policies.c.id.label("restart_policy_id"),
+            models.restart_policies.c.name.label("restart_policy_name"),
+            models.execution_envs.c.id.label("execution_env_id"),
+            models.execution_envs.c.url.label("execution_env_url"),
+        )
+        .select_from(
+            models.activations.join(models.rulebooks)
+            .join(models.inventories)
+            .join(models.extra_vars)
+            .join(models.playbooks)
+            .join(models.restart_policies)
+            .join(models.execution_envs)
+        )
+        .where(models.activations.c.id == activation_id)
+    )
+    result = (await db.execute(query)).one_or_none()
+    if result is None:
+        raise HTTPException(status_code=404, detail="Activation Not Found.")
+    return result
+
+
+@router.patch(
+    "/api/activation/{activation_id}",
+    response_model=schemas.ActivationBaseRead,
+    operation_id="update_activation",
+)
+async def update_activation(
+    activation_id: int,
+    activation: schemas.ActivationUpdate,
+    db: AsyncSession = Depends(get_db_session),
+):
+    stored_activation = (
+        await db.execute(
+            sa.select(models.activations).where(
+                models.activations.c.id == activation_id
+            )
+        )
+    ).one_or_none()
+    if stored_activation is None:
+        raise HTTPException(status_code=404, detail="Activation Not Found.")
+
+    await db.execute(
+        sa.update(models.activations)
+        .where(models.activations.c.id == activation_id)
+        .values(
+            name=activation.name,
+            description=activation.description,
+            activation_enabled=activation.activation_enabled,
+        )
+    )
+    await db.commit()
+
+    updated_activation = (
+        await db.execute(
+            sa.select(models.activations).where(
+                models.activations.c.id == activation_id
+            )
+        )
+    ).one_or_none()
+
+    return updated_activation

--- a/ansible_events_ui/schemas.py
+++ b/ansible_events_ui/schemas.py
@@ -64,8 +64,7 @@ class ExtravarsRef(BaseModel):
     id: Optional[int]
 
 
-class Activation(BaseModel):
-    id: Optional[int]
+class ActivationCreate(BaseModel):
     name: StrictStr
     description: Optional[StrictStr]
     execution_env_id: int
@@ -75,6 +74,30 @@ class Activation(BaseModel):
     playbook_id: int
     activation_enabled: bool
     extra_var_id: int
+
+
+class ActivationBaseRead(ActivationCreate):
+    id: int
+
+
+class ActivationRead(ActivationBaseRead):
+    activation_status: Optional[StrictStr]
+    restarted_at: Optional[datetime]
+    restarted_count: int
+    created_at: datetime
+    modified_at: datetime
+    rulebook_name: StrictStr
+    inventory_name: StrictStr
+    extra_var_name: StrictStr
+    playbook_name: StrictStr
+    restart_policy_name: StrictStr
+    execution_env_url: StrictStr
+
+
+class ActivationUpdate(BaseModel):
+    name: StrictStr
+    description: Optional[StrictStr]
+    activation_enabled: bool
 
 
 class ActivationInstance(BaseModel):

--- a/tests/integration/api/test_activation.py
+++ b/tests/integration/api/test_activation.py
@@ -7,7 +7,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from ansible_events_ui.db import models
 
 TEST_ACTIVATION = {
-    "id": 1,
     "name": "test-activation",
     "rulebook_id": 1,
     "inventory_id": 1,
@@ -48,30 +47,93 @@ TEST_RULEBOOK = """
 TEST_PLAYBOOK = TEST_RULEBOOK
 
 
+async def _create_activation_dependent_objects(
+    client: AsyncClient, db: AsyncSession
+):
+    (extra_var_id,) = (
+        await db.execute(
+            sa.insert(models.extra_vars).values(
+                name="vars.yml", extra_var=TEST_EXTRA_VAR
+            )
+        )
+    ).inserted_primary_key
+
+    (inventory_id,) = (
+        await db.execute(
+            sa.insert(models.inventories).values(
+                name="inventory.yml", inventory=TEST_INVENTORY
+            )
+        )
+    ).inserted_primary_key
+
+    (rulebook_id,) = (
+        await db.execute(
+            sa.insert(models.rulebooks).values(
+                name="ruleset.yml", rulesets=TEST_RULEBOOK
+            )
+        )
+    ).inserted_primary_key
+
+    (playbook_id,) = (
+        await db.execute(
+            sa.insert(models.playbooks).values(
+                name="hello.yml", playbook=TEST_PLAYBOOK
+            )
+        )
+    ).inserted_primary_key
+
+    (restart_policy_id,) = (
+        await db.execute(
+            sa.insert(models.restart_policies).values(name="test_restart")
+        )
+    ).inserted_primary_key
+
+    (execution_env_id,) = (
+        await db.execute(
+            sa.insert(models.execution_envs).values(
+                url="quay.io/bthomass/ansible-events:latest"
+            )
+        )
+    ).inserted_primary_key
+    await db.commit()
+
+    foreign_keys = {
+        "extra_var_id": extra_var_id,
+        "inventory_id": inventory_id,
+        "rulebook_id": rulebook_id,
+        "playbook_id": playbook_id,
+        "restart_policy_id": restart_policy_id,
+        "execution_env_id": execution_env_id,
+    }
+
+    return foreign_keys
+
+
+async def _create_activation(
+    client: AsyncClient, db: AsyncSession, foreign_keys
+):
+    (activation_id,) = (
+        await db.execute(
+            sa.insert(models.activations).values(
+                name=TEST_ACTIVATION["name"],
+                description=TEST_ACTIVATION["description"],
+                rulebook_id=foreign_keys["rulebook_id"],
+                inventory_id=foreign_keys["inventory_id"],
+                execution_env_id=foreign_keys["execution_env_id"],
+                restart_policy_id=foreign_keys["restart_policy_id"],
+                playbook_id=foreign_keys["playbook_id"],
+                activation_enabled=TEST_ACTIVATION["activation_enabled"],
+                extra_var_id=foreign_keys["extra_var_id"],
+            )
+        )
+    ).inserted_primary_key
+
+    return activation_id
+
+
 @pytest.mark.asyncio
 async def test_create_activation(client: AsyncClient, db: AsyncSession):
-    query = sa.insert(models.extra_vars).values(
-        name="vars.yml", extra_var=TEST_EXTRA_VAR
-    )
-    await db.execute(query)
-    query = sa.insert(models.inventories).values(
-        name="inventory.yml", inventory=TEST_INVENTORY
-    )
-    await db.execute(query)
-    query = sa.insert(models.rulebooks).values(
-        name="ruleset.yml", rulesets=TEST_RULEBOOK
-    )
-    await db.execute(query)
-    query = sa.insert(models.playbooks).values(
-        name="hello.yml", playbook=TEST_PLAYBOOK
-    )
-    await db.execute(query)
-    query = sa.insert(models.restart_policies).values(name="test_restart")
-    await db.execute(query)
-    query = sa.insert(models.execution_envs).values(
-        url="quay.io/bthomass/ansible-events:latest"
-    )
-    await db.execute(query)
+    await _create_activation_dependent_objects(client, db)
 
     response = await client.post(
         "/api/activations/",
@@ -79,13 +141,11 @@ async def test_create_activation(client: AsyncClient, db: AsyncSession):
     )
     assert response.status_code == status_codes.HTTP_200_OK
     data = response.json()
-    assert "id" in data
     assert data["name"] == TEST_ACTIVATION["name"]
 
     activations = (await db.execute(sa.select(models.activations))).all()
     assert len(activations) == 1
     activation = activations[0]
-    assert activation["id"] == data["id"]
     assert activation["name"] == TEST_ACTIVATION["name"]
     assert (
         activation["activation_enabled"]
@@ -97,34 +157,13 @@ async def test_create_activation(client: AsyncClient, db: AsyncSession):
 async def test_delete_activation_instance(
     client: AsyncClient, db: AsyncSession
 ):
-    query = sa.insert(models.extra_vars).values(
-        name="vars.yml", extra_var=TEST_EXTRA_VAR
-    )
-    await db.execute(query)
-    extra_var = (await db.execute(sa.select(models.extra_vars))).first()
-
-    query = sa.insert(models.inventories).values(
-        name="inventory.yml", inventory=TEST_INVENTORY
-    )
-    await db.execute(query)
-    inventory = (await db.execute(sa.select(models.inventories))).first()
-
-    query = sa.insert(models.rulebooks).values(
-        name="ruleset.yml", rulesets=TEST_RULEBOOK
-    )
-    await db.execute(query)
-    rulebook = (await db.execute(sa.select(models.rulebooks))).first()
-
-    query = sa.insert(models.playbooks).values(
-        name="hello.yml", playbook=TEST_PLAYBOOK
-    )
-    await db.execute(query)
+    foreign_keys = await _create_activation_dependent_objects(client, db)
 
     query = sa.insert(models.activation_instances).values(
         name="test-activation",
-        rulebook_id=rulebook.id,
-        inventory_id=inventory.id,
-        extra_var_id=extra_var.id,
+        rulebook_id=foreign_keys["rulebook_id"],
+        inventory_id=foreign_keys["inventory_id"],
+        extra_var_id=foreign_keys["extra_var_id"],
     )
     await db.execute(query)
 
@@ -156,4 +195,88 @@ async def test_create_activation_bad_entity(
 @pytest.mark.asyncio
 async def test_delete_activation_not_found(client: AsyncClient):
     response = await client.delete("/api/activation_instance/1")
+    assert response.status_code == status_codes.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_read_activation(client: AsyncClient, db: AsyncSession):
+    foreign_keys = await _create_activation_dependent_objects(client, db)
+    activation_id = await _create_activation(client, db, foreign_keys)
+
+    response = await client.get(
+        f"/api/activation/{activation_id}",
+    )
+    assert response.status_code == status_codes.HTTP_200_OK
+    activation = response.json()
+    assert "id" in activation
+
+    assert activation["name"] == TEST_ACTIVATION["name"]
+    assert activation["id"] == activation_id
+    assert activation["playbook_id"] == foreign_keys["playbook_id"]
+    assert (
+        activation["activation_enabled"]
+        == TEST_ACTIVATION["activation_enabled"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_read_activation_not_found(client: AsyncClient):
+    response = await client.get("/api/activation/1")
+    assert response.status_code == status_codes.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_update_activation(client: AsyncClient, db: AsyncSession):
+    foreign_keys = await _create_activation_dependent_objects(client, db)
+    activation_id = await _create_activation(client, db, foreign_keys)
+
+    new_activation = {
+        "name": "new demo",
+        "description": "demo activation",
+        "activation_enabled": False,
+    }
+
+    response = await client.patch(
+        f"/api/activation/{activation_id}",
+        json=new_activation,
+    )
+    assert response.status_code == status_codes.HTTP_200_OK
+    activation = response.json()
+
+    assert activation["name"] == new_activation["name"]
+    assert activation["description"] == new_activation["description"]
+    assert (
+        activation["activation_enabled"]
+        == new_activation["activation_enabled"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_activation_bad_entity(
+    client: AsyncClient, db: AsyncSession
+):
+    new_activation = {
+        "name": 1,
+        "description": "demo activation",
+    }
+
+    response = await client.patch(
+        "/api/activation/1",
+        json=new_activation,
+    )
+    assert response.status_code == status_codes.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_update_activation_not_found(client: AsyncClient):
+    new_activation = {
+        "name": "new demo",
+        "description": "demo activation",
+        "activation_enabled": False,
+    }
+
+    response = await client.patch(
+        "/api/activation/1",
+        json=new_activation,
+    )
     assert response.status_code == status_codes.HTTP_404_NOT_FOUND


### PR DESCRIPTION
Add new API endpoints `/api/activation/<id>` to get/update an existing activation.

**Test Instructions:**

In order to test GET/PATCH endpoints, first create an activation by sending a POST request to `/api/activations/` with the following request body:
```
{
   "name": "demo",
   "rulebook_id": 1,
   "inventory_id": 1,
   "extra_var_id": 1,
   "description": "demo activation",
   "execution_env_id": 1,
   "restart_policy_id": 1,
   "playbook_id": 1,
   "activation_enabled": true,
}
```

NOTE: The code assumes that you already have inventory, extra vars, restart policy, playbook and execution environment created.

**GET Endpoint**

To test GET Endpoint, make a GET request to `/api/activation/<activation_id>`, by which you should expect data that is similar to the following:
```
{
    "id": 1,
    "name": "demo",
    "description": "updated activation",
    "execution_env_id": 1,
    "rulebook_id": 1,
    "inventory_id": 1,
    "restart_policy_id": 1,
    "playbook_id": 1,
    "activation_status": false,
    "extra_var_id": 1,
    "restarted_at": null,
    "restarted_count": 0,
    "created_at": "2022-08-31T19:53:11.382061+00:00",
    "modified_at": "2022-08-31T19:53:43.515323+00:00",
    "rulebook_name": "hello_events1k.yml",
    "inventory_name": "ssh_inventory.yml",
    "extra_var_name": "vars.yml",
    "playbook_name": "hello1k.yml",
    "restart_policy_name": "test policy",
    "execution_env_url": "quay.io/bthomass/ansible-events:latest"
}
```

**PATCH Endpoint**

To test PATCH Endpoint, send a PATCH request to `/api/activation/<activation_id>` with a request body that looks similar to the following:
```
{
    "name": "demo",
    "description": "activation",
    "activation_status": false
}
```
which updates the existing activation and should return data similar to the following:
```
{
    "id": 1,
    "name": "demo",
    "description": "activation",
    "execution_env_id": 1,
    "rulebook_id": 1,
    "inventory_id": 1,
    "restart_policy_id": 1,
    "playbook_id": 1,
    "activation_status": false,
    "extra_var_id": 1
}
```

Resolves: AAP-5226, AAP-5227
Also see: AAP-5262