### PR TITLE
Fix id field for project schema

### DIFF
--- a/ansible_events_ui/schemas.py
+++ b/ansible_events_ui/schemas.py
@@ -141,7 +141,6 @@ class PlaybookRef(BaseModel):
 
 
 class ProjectCreate(BaseModel):
-    id: Optional[int]
     git_hash: Optional[StrictStr]
     url: StrictStr
     name: StrictStr
@@ -149,6 +148,7 @@ class ProjectCreate(BaseModel):
 
 
 class ProjectRead(ProjectCreate):
+    id: int
     created_at: datetime
     modified_at: datetime
 


### PR DESCRIPTION
With the current definition the openapi spec indicates that an optional `id` parameter is accepted to create a new project, which is not true. 
Also, because it's optional, can not be validated in the responses, where is a mandatory field. 
