### PR TITLE
Restruct activation schema

### DIFF
--- a/ansible_events_ui/api/activation.py
+++ b/ansible_events_ui/api/activation.py
@@ -45,7 +45,7 @@ async def create_activation(
         working_directory=activation.working_directory,
         restart_policy_id=activation.restart_policy_id,
         playbook_id=activation.playbook_id,
-        activation_enabled=activation.activation_enabled,
+        is_enabled=activation.is_enabled,
         extra_var_id=activation.extra_var_id,
     )
     try:
@@ -71,12 +71,12 @@ async def read_activation(
             models.activations.c.id,
             models.activations.c.name,
             models.activations.c.description,
-            models.activations.c.activation_enabled,
-            models.activations.c.activation_status,
+            models.activations.c.is_enabled,
+            models.activations.c.status,
             models.activations.c.working_directory,
             models.activations.c.execution_environment,
             models.activations.c.restarted_at,
-            models.activations.c.restarted_count,
+            models.activations.c.restart_count,
             models.activations.c.created_at,
             models.activations.c.modified_at,
             models.rulebooks.c.id.label("rulebook_id"),
@@ -90,19 +90,52 @@ async def read_activation(
             models.restart_policies.c.id.label("restart_policy_id"),
             models.restart_policies.c.name.label("restart_policy_name"),
         )
-        .select_from(
-            models.activations.join(models.rulebooks)
-            .join(models.inventories)
-            .join(models.extra_vars)
-            .join(models.playbooks)
-            .join(models.restart_policies)
-        )
+        .select_from(models.activations)
+        .join(models.rulebooks)
+        .join(models.inventories)
+        .join(models.extra_vars)
+        .join(models.playbooks)
+        .join(models.restart_policies)
         .where(models.activations.c.id == activation_id)
     )
-    result = (await db.execute(query)).one_or_none()
-    if result is None:
+    activation = (await db.execute(query)).one_or_none()
+    if activation is None:
         raise HTTPException(status_code=404, detail="Activation Not Found.")
-    return result
+
+    response = {
+        "id": activation["id"],
+        "name": activation["name"],
+        "description": activation["description"],
+        "is_enabled": activation["is_enabled"],
+        "status": activation["status"],
+        "working_directory": activation["working_directory"],
+        "execution_environment": activation["execution_environment"],
+        "restarted_at": activation["restarted_at"],
+        "restart_count": activation["restart_count"],
+        "created_at": activation["created_at"],
+        "modified_at": activation["modified_at"],
+        "rulebook": {
+            "id": activation["rulebook_id"],
+            "name": activation["rulebook_name"],
+        },
+        "inventory": {
+            "id": activation["inventory_id"],
+            "name": activation["inventory_name"],
+        },
+        "playbook": {
+            "id": activation["playbook_id"],
+            "name": activation["playbook_name"],
+        },
+        "restart_policy": {
+            "id": activation["restart_policy_id"],
+            "name": activation["restart_policy_name"],
+        },
+        "extra_var": {
+            "id": activation["extra_var_id"],
+            "name": activation["extra_var_name"],
+        },
+    }
+    return response
 
 
 @router.patch(
@@ -131,7 +164,7 @@ async def update_activation(
         .values(
             name=activation.name,
             description=activation.description,
-            activation_enabled=activation.activation_enabled,
+            is_enabled=activation.is_enabled,
         )
     )
     await db.commit()

--- a/ansible_events_ui/db/migrations/versions/202209131406_74607f5764f9_update_activation_table_columns.py
+++ b/ansible_events_ui/db/migrations/versions/202209131406_74607f5764f9_update_activation_table_columns.py
@@ -1,0 +1,56 @@
+"""Update activation table columns.
+
+Revision ID: 74607f5764f9
+Revises: 93a62b2e768b
+Create Date: 2022-09-13 14:06:07.046278+00:00
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "74607f5764f9"
+down_revision = "93a62b2e768b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "activation",
+        "activation_status",
+        nullable=True,
+        new_column_name="status",
+    )
+    op.alter_column(
+        "activation",
+        "activation_enabled",
+        nullable=False,
+        new_column_name="is_enabled",
+    )
+    op.alter_column(
+        "activation",
+        "restarted_count",
+        nullable=False,
+        new_column_name="restart_count",
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "activation",
+        "status",
+        nullable=True,
+        new_column_name="activation_status",
+    )
+    op.alter_column(
+        "activation",
+        "is_enabled",
+        nullable=False,
+        new_column_name="activation_enabled",
+    )
+    op.alter_column(
+        "activation",
+        "restart_count",
+        nullable=False,
+        new_column_name="restarted_count",
+    )

--- a/ansible_events_ui/db/models/activation.py
+++ b/ansible_events_ui/db/models/activation.py
@@ -48,10 +48,10 @@ activations = sa.Table(
         sa.ForeignKey("playbook.id", ondelete="CASCADE"),
         nullable=False,
     ),
-    sa.Column("activation_status", sa.String),
-    sa.Column("activation_enabled", sa.Boolean, nullable=False),
+    sa.Column("status", sa.String),
+    sa.Column("is_enabled", sa.Boolean, nullable=False),
     sa.Column("restarted_at", sa.DateTime(timezone=True)),
-    sa.Column("restarted_count", sa.Integer, nullable=False, default=0),
+    sa.Column("restart_count", sa.Integer, nullable=False, default=0),
     sa.Column(
         "created_at",
         sa.DateTime(timezone=True),

--- a/ansible_events_ui/schemas.py
+++ b/ansible_events_ui/schemas.py
@@ -42,6 +42,11 @@ class Rulebook(BaseModel):
     id: Optional[int]
 
 
+class RulebookRef(BaseModel):
+    id: Optional[int]
+    name: StrictStr
+
+
 class Inventory(BaseModel):
     name: StrictStr
     inventory: StrictStr
@@ -62,42 +67,6 @@ class Extravars(BaseModel):
 class ExtravarsRef(BaseModel):
     name: StrictStr
     id: Optional[int]
-
-
-class ActivationCreate(BaseModel):
-    name: StrictStr
-    description: Optional[StrictStr]
-    rulebook_id: int
-    inventory_id: int
-    restart_policy_id: int
-    playbook_id: int
-    activation_enabled: bool
-    extra_var_id: int
-    working_directory: StrictStr
-    execution_environment: StrictStr
-
-
-class ActivationBaseRead(ActivationCreate):
-    id: int
-
-
-class ActivationRead(ActivationBaseRead):
-    activation_status: Optional[StrictStr]
-    restarted_at: Optional[datetime]
-    restarted_count: int
-    created_at: datetime
-    modified_at: datetime
-    rulebook_name: StrictStr
-    inventory_name: StrictStr
-    extra_var_name: StrictStr
-    playbook_name: StrictStr
-    restart_policy_name: StrictStr
-
-
-class ActivationUpdate(BaseModel):
-    name: StrictStr
-    description: Optional[StrictStr]
-    activation_enabled: bool
 
 
 class ActivationInstance(BaseModel):
@@ -168,6 +137,53 @@ class ProjectList(BaseModel):
 
 class ProjectUpdate(BaseModel):
     name: StrictStr
+
+
+class RestartPolicy(BaseModel):
+    id: int
+    name: StrictStr
+
+
+class ActivationCreate(BaseModel):
+    name: StrictStr
+    description: Optional[StrictStr]
+    rulebook_id: int
+    inventory_id: int
+    restart_policy_id: int
+    playbook_id: int
+    is_enabled: bool
+    extra_var_id: int
+    working_directory: StrictStr
+    execution_environment: StrictStr
+
+
+class ActivationBaseRead(ActivationCreate):
+    id: int
+
+
+class ActivationRead(BaseModel):
+    id: int
+    name: StrictStr
+    description: Optional[StrictStr]
+    status: Optional[StrictStr]
+    is_enabled: bool
+    working_directory: StrictStr
+    execution_environment: StrictStr
+    rulebook: RulebookRef
+    inventory: InventoryRef
+    extra_var: ExtravarsRef
+    playbook: PlaybookRef
+    restart_policy: RestartPolicy
+    restarted_at: Optional[datetime]
+    restart_count: int
+    created_at: datetime
+    modified_at: datetime
+
+
+class ActivationUpdate(BaseModel):
+    name: StrictStr
+    description: Optional[StrictStr]
+    is_enabled: bool
 
 
 # Fast API Users

--- a/tests/integration/api/test_activation.py
+++ b/tests/integration/api/test_activation.py
@@ -14,7 +14,7 @@ TEST_ACTIVATION = {
     "description": "demo activation",
     "restart_policy_id": 1,
     "playbook_id": 1,
-    "activation_enabled": True,
+    "is_enabled": True,
     "working_directory": "/tmp",
     "execution_environment": "quay.io/ansible/eda-project",
 }
@@ -114,7 +114,7 @@ async def _create_activation(
                 working_directory=TEST_ACTIVATION["working_directory"],
                 restart_policy_id=foreign_keys["restart_policy_id"],
                 playbook_id=foreign_keys["playbook_id"],
-                activation_enabled=TEST_ACTIVATION["activation_enabled"],
+                is_enabled=TEST_ACTIVATION["is_enabled"],
                 extra_var_id=foreign_keys["extra_var_id"],
             )
         )
@@ -139,10 +139,7 @@ async def test_create_activation(client: AsyncClient, db: AsyncSession):
     assert len(activations) == 1
     activation = activations[0]
     assert activation["name"] == TEST_ACTIVATION["name"]
-    assert (
-        activation["activation_enabled"]
-        == TEST_ACTIVATION["activation_enabled"]
-    )
+    assert activation["is_enabled"] == TEST_ACTIVATION["is_enabled"]
 
 
 @pytest.mark.asyncio
@@ -204,11 +201,29 @@ async def test_read_activation(client: AsyncClient, db: AsyncSession):
 
     assert activation["name"] == TEST_ACTIVATION["name"]
     assert activation["id"] == activation_id
-    assert activation["playbook_id"] == foreign_keys["playbook_id"]
+    assert activation["is_enabled"] == TEST_ACTIVATION["is_enabled"]
+    assert activation["working_directory"] == "/tmp"
     assert (
-        activation["activation_enabled"]
-        == TEST_ACTIVATION["activation_enabled"]
+        activation["execution_environment"]
+        == TEST_ACTIVATION["execution_environment"]
     )
+    assert activation["rulebook"] == {
+        "id": foreign_keys["rulebook_id"],
+        "name": "ruleset.yml",
+    }
+    assert activation["inventory"] == {
+        "id": foreign_keys["inventory_id"],
+        "name": "inventory.yml",
+    }
+    assert activation["extra_var"] == {
+        "id": foreign_keys["extra_var_id"],
+        "name": "vars.yml",
+    }
+    assert activation["playbook"] == {
+        "id": foreign_keys["playbook_id"],
+        "name": "hello.yml",
+    }
+    assert activation["restart_policy"]["name"] == "test_restart"
 
 
 @pytest.mark.asyncio
@@ -225,7 +240,7 @@ async def test_update_activation(client: AsyncClient, db: AsyncSession):
     new_activation = {
         "name": "new demo",
         "description": "demo activation",
-        "activation_enabled": False,
+        "is_enabled": False,
     }
 
     response = await client.patch(
@@ -237,10 +252,7 @@ async def test_update_activation(client: AsyncClient, db: AsyncSession):
 
     assert activation["name"] == new_activation["name"]
     assert activation["description"] == new_activation["description"]
-    assert (
-        activation["activation_enabled"]
-        == new_activation["activation_enabled"]
-    )
+    assert activation["is_enabled"] == new_activation["is_enabled"]
 
 
 @pytest.mark.asyncio
@@ -264,7 +276,7 @@ async def test_update_activation_not_found(client: AsyncClient):
     new_activation = {
         "name": "new demo",
         "description": "demo activation",
-        "activation_enabled": False,
+        "is_enabled": False,
     }
 
     response = await client.patch(


### PR DESCRIPTION
This changes the structure of the activation schemas to have a nested format for dependent objects, as per @cutwater 's comment [here](https://github.com/benthomasson/ansible-events-ui/pull/93#issuecomment-1238172220).

With these changes, the ActivationRead response looks similar to the following:
```
{
    "id": 3,
    "name": "test",
    "description": "demo activation",
    "activation_status": null,
    "activation_enabled": true,
    "rulebook": {
        "name": "hello_events1k.yml",
        "rulesets": "---\n- name: Hello Events 1k\n  hosts: all\n  sources:\n    - benthomasson.eda.range:\n        limit: 5\n  rules:\n    - name: Say Hello\n      condition: event.i == 1\n      action:\n        run_playbook:\n          name: playbooks/hello1k.yml\n...\n",
        "id": 1
    },
    "inventory": {
        "name": "ssh_inventory.yml",
        "inventory": "all:\n  hosts:\n    localhost:\n      ansible_user: ansible\n      ansible_python_interpreter: /usr/bin/python3\n",
        "id": 1
    },
    "extra_var": {
        "name": "vars.yml",
        "extra_var": "---\n{}\n...\n",
        "id": 1
    },
    "playbook": {
        "id": 1,
        "name": "hello1k.yml"
    },
    "restart_policy": {
        "id": 2,
        "name": "test policy"
    },
    "execution_env": {
        "id": 1,
        "url": "quay.io/bthomass/ansible-events:latest"
    },
    "restarted_at": null,
    "restarted_count": 0,
    "created_at": "2022-09-07T13:23:24.871044+00:00",
    "modified_at": "2022-09-07T13:23:24.871044+00:00"
}
```

NOTE: This is a follow-up change for this [PR](https://github.com/benthomasson/ansible-events-ui/pull/93), and should be merged following that. 