### PR TITLE
Disable PostgreSQL JIT compilation

### DIFF
--- a/tools/docker/postgres/conf.d/pg_jit.conf
+++ b/tools/docker/postgres/conf.d/pg_jit.conf
@@ -1,0 +1,12 @@
+# Disable PostgreSQL JIT compilation
+# NOTE(cutwater): This is a workaround for database introspection long execution time.
+#   Background: For native PostgreSQL enum types, asyncpg connector library executes
+#   an introspection query [1] once per connection. Disabling JIT significantly reduces
+#   execution time of the query:
+#     - JIT enabled: ~600ms
+#     - JIT disabled ~2.4-2.8ms
+#   References:
+#     - 1. https://gist.github.com/cutwater/e83c0eb55448d78965f087ae44c7d4e2
+#   See also:
+#     - https://github.com/MagicStack/asyncpg/issues/530
+jit = off


### PR DESCRIPTION
This is a workaround for database introspection long execution time.

**Background:** 

For native PostgreSQL enum types, asyncpg connector library executes
an introspection query [1] once per connection. Disabling JIT significantly reduces
execution time of the query:
   - JIT enabled: ~600ms
   - JIT disabled ~2.4-2.8ms

**References:**
  [1] https://gist.github.com/cutwater/e83c0eb55448d78965f087ae44c7d4e2