### PR TITLE
[AAP-5705]: Update Project Endpoint

### DIFF
--- a/ansible_events_ui/db/migrations/versions/202209162048_9f6b44aa0df8_project_name_unique.py
+++ b/ansible_events_ui/db/migrations/versions/202209162048_9f6b44aa0df8_project_name_unique.py
@@ -1,0 +1,22 @@
+"""project name unique.
+
+Revision ID: 9f6b44aa0df8
+Revises: 34bca36e407d
+Create Date: 2022-09-16 20:48:01.987096+00:00
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "9f6b44aa0df8"
+down_revision = "34bca36e407d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_unique_constraint(op.f("uq_project_name"), "project", ["name"])
+
+
+def downgrade() -> None:
+    op.drop_constraint(op.f("uq_project_name"), "project", type_="unique")

--- a/ansible_events_ui/db/models/project.py
+++ b/ansible_events_ui/db/models/project.py
@@ -21,7 +21,7 @@ projects = sa.Table(
     ),
     sa.Column("git_hash", sa.String),
     sa.Column("url", sa.String),
-    sa.Column("name", sa.String),
+    sa.Column("name", sa.String, unique=True),
     sa.Column("description", sa.String),
     sa.Column(
         "created_at",

--- a/ansible_events_ui/schemas.py
+++ b/ansible_events_ui/schemas.py
@@ -136,7 +136,8 @@ class ProjectList(BaseModel):
 
 
 class ProjectUpdate(BaseModel):
-    name: StrictStr
+    name: Optional[StrictStr]
+    description: Optional[StrictStr]
 
 
 class RestartPolicy(BaseModel):

--- a/tests/integration/api/test_project.py
+++ b/tests/integration/api/test_project.py
@@ -139,7 +139,7 @@ async def test_create_project(
         "/api/projects/",
         json=TEST_PROJECT,
     )
-    assert response.status_code == status_codes.HTTP_200_OK
+    assert response.status_code == status_codes.HTTP_201_CREATED
     data = response.json()
     assert "id" in data
     assert data["name"] == TEST_PROJECT["name"]


### PR DESCRIPTION
### AAP-5705
Jira ticket: [AAP-5705](https://issues.redhat.com/browse/AAP-5705)

Small updates for project endpoints:
- create endpoint returns a 201 status and only allows unique name parameter
- description parameter added to update method (both name and description are optional)

#### Testing instructions:
1. Create Project: POST `http://localhost:8080/api/projects/`
```
{
    "url": "https://github.com/benthomasson/eda-project",
    "name": "testing",
    "description": "testing"
}
```
Should receive a 201 status and response of the project object

2. Create Project: POST `http://localhost:8080/api/projects/` with the same body should get a 422 response with the following body
```
{
    "detail": "Project with name 'testing' already exists"
}
```
3.  Update Project: PATCH `http://localhost:8080/api/projects/{id}` (should be able to pass full body or 1 parameter)
```
{
    "name": "update test",
    "description": "update testing"
}
```