### PR TITLE
Change shutdown of DB to use docker-compose

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -138,7 +138,6 @@ tasks:
       - task: dev:ui:stop
       - task: dev:api:stop
       - task: dev:services:stop
-      - task: dev:services:clean
 
   docker:
     desc: "Run docker-compose with specified CLI arguments."

--- a/scripts/eda_dev.sh
+++ b/scripts/eda_dev.sh
@@ -114,19 +114,19 @@ stop-events-services() {
   log-info "Stopping EDA Services (eda-postgres)"
   cd "${EDA_PROJECT_HOME}"
 
-  if docker inspect --format '{{.Name}}' eda-postgres > /dev/null 2>&1 ; then
-    log-debug "docker-compose -p ansible-events -f tools/docker/docker-compose.yml up -d postgres"
-    docker-compose -p ansible-events -f tools/docker/docker-compose.yml up -d postgres
+  if [[ $(docker inspect --format '{{json .State.Running}}' eda-postgres) = "true" ]]; then
+    log-debug "docker-compose -p ansible-events -f tools/docker/docker-compose.yml down"
+    docker-compose -p ansible-events -f tools/docker/docker-compose.yml down
   fi
 }
 
 clean-events-services() {
-  log-info "Cleaning up EDA Services (eda-postgres)"
-  if  docker images --format '{{.Repository}}' postgres > /dev/null 2>&1; then
-    log-debug "docker rmi -f eda-postgres"
-    docker rmi -f eda-postgres > /dev/null 2>&1
+  log-info "Cleaning up EDA Services (postgres)"
+  if docker images --format '{{.Repository}}' postgres| grep postgres > /dev/null 2>&1; then
+    log-debug "docker rmi -f postgres:13"
+    docker rmi -f postgres:13 > /dev/null 2>&1
   fi
-  if docker volume inspect -f '{{.Name}}' ansible-events_postgres_data > /dev/null 2>&1; then
+  if docker volume inspect -f '{{.Name}}' ansible-events_postgres_data| grep ansible-events_postgres_data > /dev/null 2>&1; then
     log-debug "docker volume rm ansible-events_postgres_data"
     docker volume rm ansible-events_postgres_data > /dev/null 2>&1
   fi


### PR DESCRIPTION
[[AAP-5834](https://issues.redhat.com/browse/AAP-5834)] - Add task for separate DB cleanup

shutdown of DB to use docker-compose
removed deletion of volume on when shutting down the services

Testing:

1. Startup dev env 
`task dev:all:start`
2. Create the test user
`scripts/createuser.sh dev_user@redhat.com none2tuff`
3. load in some projects via the ui
4. Restart everything
`task dev:all:stop dev:all:start`
5. Verify you can log in and you still see your project details
6. Stop everything and cleanup
`task dev:all:stop`
`task dev:services:clean`
7. verify the login no longer works, re-add the user and make sure no projects exist