### PR TITLE
Add the removal of PVC & PV CRD's and images when running minikube:cl…

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -196,6 +196,7 @@ tasks:
 
   minikube:build:
     desc: "Build docker image and push to minikube"
+    deps: [minikube:clean]
     cmds:
       - task: minikube
         vars:
@@ -203,7 +204,6 @@ tasks:
 
   minikube:deploy:
     desc: "Build deployment and deploy to minikube"
-    deps: [minikube:clean]
     cmds:
       - task: minikube
         vars:

--- a/scripts/eda_kube.sh
+++ b/scripts/eda_kube.sh
@@ -48,8 +48,9 @@ build-deployment() {
   local _ui_image="eda-frontend:${1}"
   local _api_image="eda-server:${1}"
 
-  log-info "Deployment Directory: ${DEPLOY_DIR}/temp"
+  log-info "Using Deployment Directory: ${DEPLOY_DIR}/temp"
 
+  remove-deployment-tempdir
   [ -d "${DEPLOY_DIR}"/temp ] || mkdir "${DEPLOY_DIR}"/temp
 
   log-debug "kustomize edit set image eda-server=${_api_image}"
@@ -82,31 +83,46 @@ build-server() {
 build-all() {
   build-frontend "${1}"
   build-server "${1}"
+  build-deployment "${1}"
 }
 
 remove-image() {
   local _image_name="${1}"
 
-  log-info "Removing image ${_image_name} from minikube registry"
-  log-debug "minikube image rm ${_image_name}"
-  minikube image rm "${_image_name}"
+  if minikube image ls | grep "${_image_name}" &> /dev/null; then
+    log-info "Removing image ${_image_name} from minikube registry"
+    log-debug "minikube image rm ${_image_name}"
+    minikube image rm "${_image_name}"
+  fi
+}
+
+remove-deployment-tempdir() {
+  if [ -d "${DEPLOY_DIR}"/temp ]; then
+    log-debug "rm -rf ${DEPLOY_DIR}/temp"
+    rm -rf "${DEPLOY_DIR}"/temp
+  else
+    log-debug "${DEPLOY_DIR}/temp does not exist"
+  fi
 }
 
 deploy() {
   local _image="${1}"
 
-  if ! kubectl get ns -o jsonpath='{..name}'| grep "${NAMESPACE}" &> /dev/null; then
-    log-debug "kubectl create namespace ${NAMESPACE}"
-    kubectl create namespace "${NAMESPACE}"
+  if [ -d "${DEPLOY_DIR}"/temp ]; then
+    if ! kubectl get ns -o jsonpath='{..name}'| grep "${NAMESPACE}" &> /dev/null; then
+      log-debug "kubectl create namespace ${NAMESPACE}"
+      kubectl create namespace "${NAMESPACE}"
+    fi
+
+    kubectl config set-context --current --namespace="${NAMESPACE}"
+
+    log-info "deploying eda to ${NAMESPACE}"
+    log-debug "kubectl apply -f ${DEPLOY_DIR}/temp"
+    kubectl apply -f "${DEPLOY_DIR}"/temp
+
+  else
+    log-info "You must run 'minikube:build' before running minikube:deploy"
   fi
-
-  kubectl config set-context --current --namespace="${NAMESPACE}"
-
-  build-deployment "${_image}"
-
-  log-info "deploying eda to ${NAMESPACE}"
-  log-debug "kubectl apply -f ${DEPLOY_DIR}/temp"
-  kubectl apply -f "${DEPLOY_DIR}"/temp
 }
 
 clean-deployment() {
@@ -114,20 +130,15 @@ clean-deployment() {
   if kubectl get ns -o jsonpath='{..name}'| grep "${NAMESPACE}" &> /dev/null; then
     log-debug "kubectl delete all -l 'app in (eda-server, eda-frontend, eda-postgres)' -n ${NAMESPACE}"
     kubectl delete all -l 'app in (eda-server, eda-frontend, eda-postgres)' -n "${NAMESPACE}"
-    log-debug "kubectl delete pvc --all -n ${NAMESPACE}"
-    kubectl delete pvc --all -n "${NAMESPACE}"
-    log-debug "kubectl delete pv --all -n ${NAMESPACE}"
-    kubectl delete pv --all -n "${NAMESPACE}"
+    log-debug "kubectl delete pvc --all --grace-period=0 --force -n ${NAMESPACE}"
+    kubectl delete pvc --all --grace-period=0 --force -n "${NAMESPACE}"
+    log-debug "kubectl delete pv --all --grace-period=0 --force -n ${NAMESPACE}"
+    kubectl delete pv --all --grace-period=0 --force -n "${NAMESPACE}"
   else
-    log-warn "${NAMESPACE} does not exist"
+    log-debug "${NAMESPACE} does not exist"
   fi
 
-  if [ -d "${DEPLOY_DIR}"/temp ]; then
-    log-debug "rm -rf ${DEPLOY_DIR}/temp"
-    rm -rf "${DEPLOY_DIR}"/temp
-  else
-    log-warn "${DEPLOY_DIR}/temp does not exist"
-  fi
+  remove-deployment-tempdir
 
   remove-image postgres:13
   remove-image nginx:"${VERSION}"


### PR DESCRIPTION
[[AAP-5886](https://issues.redhat.com/browse/AAP-5886)] - Adjust cleanup in minikube

Testing:

Run the following tasks
`task minikube:build`
`task minikube:deploy`
`task minikube:clean`

Check minikube to make sure no resources or images for EDA are left behind. You can use minikube UI by running the following.
`minikube dashboard`

To see if the images were deleted run the following command
`minikube image ls`