### PR TITLE
Fix bearer auth endpoint

### DIFF
--- a/ansible_events_ui/users.py
+++ b/ansible_events_ui/users.py
@@ -81,7 +81,7 @@ cookie_backend = AuthenticationBackend(
 )
 bearer_backend = AuthenticationBackend(
     name="bearer",
-    transport=BearerTransport(tokenUrl="api/auth/bearer/login"),
+    transport=BearerTransport(tokenUrl="auth/bearer/login"),
     get_strategy=get_jwt_strategy,
 )
 


### PR DESCRIPTION
After the changes introduced by https://github.com/ansible/eda-server/pull/104 bearer auth from swagger is broken, this PR fixes it. 