### PR TITLE
[AAP-5230]: Add GET endpoints for audit_rule details,jobs,hosts,events

### DIFF
--- a/ansible_events_ui/api/__init__.py
+++ b/ansible_events_ui/api/__init__.py
@@ -26,6 +26,7 @@ from ansible_events_ui.users import (
 )
 
 from .activation import router as activation_router
+from .audit_rule import router as audit_rule_router
 from .job import router as job_router
 from .project import router as project_router
 from .rulebook import router as rulebook_router
@@ -37,6 +38,7 @@ router.include_router(activation_router)
 router.include_router(job_router)
 router.include_router(rulebook_router)
 router.include_router(project_router)
+router.include_router(audit_rule_router)
 
 
 # Determine host status based on event type

--- a/ansible_events_ui/api/audit_rule.py
+++ b/ansible_events_ui/api/audit_rule.py
@@ -1,0 +1,189 @@
+from typing import List
+
+import sqlalchemy as sa
+from fastapi import APIRouter, Depends, status
+from fastapi.exceptions import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ansible_events_ui import schema
+from ansible_events_ui.db import models
+from ansible_events_ui.db.dependency import get_db_session
+
+router = APIRouter(tags=["audit_rules"])
+
+
+@router.get(
+    "/api/audit/rule/{rule_id}/details",
+    response_model=schema.AuditRule,
+    operation_id="read_audit_rule_details",
+)
+async def read_audit_rule_details(
+    rule_id: int, db: AsyncSession = Depends(get_db_session)
+):
+    query = (
+        sa.select(
+            models.audit_rules.c.name,
+            models.audit_rules.c.description,
+            models.audit_rules.c.status,
+            models.audit_rules.c.ruleset_id,
+            models.rulesets.c.name.label("ruleset_name"),
+            models.audit_rules.c.activation_instance_id,
+            models.activation_instances.c.name.label(
+                "activation_instance_name"
+            ),
+            models.audit_rules.c.created_at,
+            models.audit_rules.c.fired_date,
+            models.audit_rules.c.definition,
+        )
+        .select_from(
+            models.audit_rules.join(models.rulesets).join(
+                models.activation_instances
+            )
+        )
+        .filter(models.audit_rules.c.id == rule_id)
+    )
+    row = (await db.execute(query)).first()
+    if not row:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    return {
+        "name": row["name"],
+        "description": row["description"],
+        "status": row["status"],
+        "activation": {
+            "id": row["activation_instance_id"],
+            "name": row["activation_instance_name"],
+        },
+        "ruleset": {
+            "id": row["ruleset_id"],
+            "name": row["ruleset_name"],
+        },
+        "created_at": row["created_at"],
+        "fired_date": row["fired_date"],
+        "definition": row["definition"],
+    }
+
+
+@router.get(
+    "/api/audit/rule/{rule_id}/jobs",
+    response_model=List[schema.AuditRuleJobInstance],
+    operation_id="list_audit_rule_jobs",
+)
+async def list_audit_rule_jobs(
+    rule_id: int, db: AsyncSession = Depends(get_db_session)
+):
+    query = (
+        sa.select(
+            models.audit_rules.c.id,
+            models.audit_rules.c.job_instance_id,
+            models.audit_rules.c.status,
+            models.audit_rules.c.fired_date,
+        )
+        .select_from(models.audit_rules)
+        .filter(models.audit_rules.c.id == rule_id)
+    )
+    rows = (await db.execute(query)).all()
+    if not rows:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    response = []
+    for row in rows:
+        response.append(
+            {
+                "id": row["job_instance_id"],
+                "status": row["status"],
+                "last_fired_date": row["fired_date"],
+            }
+        )
+    return response
+
+
+@router.get(
+    "/api/audit/rule/{rule_id}/hosts",
+    response_model=List[schema.AuditRuleHost],
+    operation_id="list_audit_rule_hosts",
+)
+async def list_audit_rule_hosts(
+    rule_id: int, db: AsyncSession = Depends(get_db_session)
+):
+    query = (
+        sa.select(
+            models.audit_rules.c.id,
+            models.audit_rules.c.job_instance_id,
+            models.job_instances.c.uuid,
+            models.job_instance_hosts.c.id.label("host_id"),
+            models.job_instance_hosts.c.status,
+            models.job_instance_hosts.c.host,
+        )
+        .select_from(models.audit_rules)
+        .join(
+            models.job_instances,
+            models.audit_rules.c.job_instance_id == models.job_instances.c.id,
+        )
+        .join(
+            models.job_instance_hosts,
+            models.job_instances.c.uuid
+            == models.job_instance_hosts.c.job_uuid,
+        )
+        .filter(models.audit_rules.c.id == rule_id)
+    )
+    rows = (await db.execute(query)).all()
+    if not rows:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+
+    response = []
+    for row in rows:
+        response.append(
+            {
+                "id": row["host_id"],
+                "name": row["host"],
+                "status": row["status"],
+            }
+        )
+    return response
+
+
+@router.get(
+    "/api/audit/rule/{rule_id}/events",
+    response_model=List[schema.AuditRuleJobInstanceEvent],
+    operation_id="list_audit_rule_events",
+)
+async def list_audit_rule_events(
+    rule_id: int, db: AsyncSession = Depends(get_db_session)
+):
+    query = (
+        sa.select(
+            models.audit_rules.c.job_instance_id,
+            models.audit_rules.c.name,
+            models.job_instances.c.uuid,
+            models.job_instance_events.c.id,
+            models.job_instance_events.c.counter,
+            models.job_instance_events.c.type,
+            models.job_instance_events.c.created_at,
+        )
+        .select_from(models.audit_rules)
+        .join(
+            models.job_instances,
+            models.job_instances.c.id == models.audit_rules.c.job_instance_id,
+        )
+        .join(
+            models.job_instance_events,
+            models.job_instance_events.c.job_uuid
+            == models.job_instances.c.uuid,
+        )
+        .filter(models.audit_rules.c.id == rule_id)
+    )
+    rows = (await db.execute(query)).all()
+    if not rows:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+
+    response = []
+    for row in rows:
+        response.append(
+            {
+                "id": row["job_instance_event_id"],
+                "name": row["name"],
+                "increment_counter": row["job_instance_event_counter"],
+                "type": row["type"],
+                "timestamp": row["created_at"],
+            }
+        )
+    return response

--- a/ansible_events_ui/schema/__init__.py
+++ b/ansible_events_ui/schema/__init__.py
@@ -7,6 +7,12 @@ from .activation import (
     ActivationUpdate,
     RestartPolicy,
 )
+from .audit_rule import (
+    AuditRule,
+    AuditRuleHost,
+    AuditRuleJobInstance,
+    AuditRuleJobInstanceEvent,
+)
 from .extra_vars import Extravars, ExtravarsRef
 from .inventory import Inventory, InventoryRef
 from .job import JobInstance
@@ -37,6 +43,10 @@ __all__ = [
     "ActivationRead",
     "ActivationBaseRead",
     "ActivationCreate",
+    "AuditRule",
+    "AuditRuleJobInstance",
+    "AuditRuleJobInstanceEvent",
+    "AuditRuleHost",
     "Extravars",
     "ExtravarsRef",
     "Inventory",

--- a/ansible_events_ui/schema/audit_rule.py
+++ b/ansible_events_ui/schema/audit_rule.py
@@ -1,0 +1,42 @@
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, StrictStr
+
+from .rulebook import RuleRulesetRef
+
+
+class AuditRuleActivationRef(BaseModel):
+    id: int
+    name: StrictStr
+
+
+class AuditRule(BaseModel):
+    name: StrictStr
+    description: Optional[StrictStr]
+    status: Optional[StrictStr]
+    activation: AuditRuleActivationRef
+    ruleset: RuleRulesetRef
+    created_at: datetime
+    fired_date: datetime
+    definition: dict
+
+
+class AuditRuleJobInstance(BaseModel):
+    id: int
+    status: Optional[StrictStr]
+    last_fired_date: datetime
+
+
+class AuditRuleJobInstanceEvent(BaseModel):
+    id: int
+    name: Optional[StrictStr]
+    increment_counter: int
+    type: Optional[StrictStr]
+    timestamp: datetime
+
+
+class AuditRuleHost(BaseModel):
+    id: int
+    name: Optional[StrictStr]
+    status: Optional[StrictStr]

--- a/tests/integration/api/test_audit_rule.py
+++ b/tests/integration/api/test_audit_rule.py
@@ -1,0 +1,302 @@
+import datetime
+
+import pytest
+import sqlalchemy as sa
+from fastapi import status as status_codes
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ansible_events_ui.db import models
+
+TEST_AUDIT_RULE = {
+    "name": "test-audit-rule",
+    "definition": {"test": "test"},
+    "status": "successful",
+}
+
+TEST_EXTRA_VAR = """
+---
+collections:
+  - community.general
+  - benthomasson.eda  # 1.3.0
+"""
+
+TEST_INVENTORY = """
+---
+all:
+    hosts:
+        localhost:
+            ansible_connection: local
+            ansible_python_interpreter: /usr/bin/python3
+"""
+
+TEST_RULEBOOK = """
+---
+- name: hello
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - debug:
+        msg: hello
+"""
+
+TEST_AUDIT_RULE_JOB = {
+    "uuid": "f4c87c90-254e-11ed-861d-0242ac120005",
+}
+
+TEST_AUDIT_RULE_JOB_EVENT = {
+    "job_uuid": "f4c87c90-254e-11ed-861d-0242ac120005",
+    "counter": 1,
+    "type": "playbook_on_start",
+    "created_at": datetime.datetime.now(),
+    "stdout": "foo",
+}
+
+TEST_AUDIT_RULE_JOB_HOST = {
+    "job_uuid": "f4c87c90-254e-11ed-861d-0242ac120005",
+    "host": "localhost",
+    "playbook": "test_playbook",
+    "play": "hello",
+    "task": "debug",
+    "status": "success",
+}
+
+RULE_NAMES = {
+    "rulebook_name": "ruleset.yml",
+    "ruleset_name": "Test simple",
+}
+
+
+async def _create_activation_dependent_objects(
+    client: AsyncClient, db: AsyncSession
+):
+    (extra_var_id,) = (
+        await db.execute(
+            sa.insert(models.extra_vars).values(
+                name="vars.yml", extra_var=TEST_EXTRA_VAR
+            )
+        )
+    ).inserted_primary_key
+
+    (inventory_id,) = (
+        await db.execute(
+            sa.insert(models.inventories).values(
+                name="inventory.yml", inventory=TEST_INVENTORY
+            )
+        )
+    ).inserted_primary_key
+
+    (rulebook_id,) = (
+        await db.execute(
+            sa.insert(models.rulebooks).values(
+                name=RULE_NAMES["rulebook_name"], rulesets=TEST_RULEBOOK
+            )
+        )
+    ).inserted_primary_key
+
+    (ruleset_id,) = (
+        await db.execute(
+            sa.insert(models.rulesets).values(
+                name=RULE_NAMES["ruleset_name"],
+                rulebook_id=rulebook_id,
+            )
+        )
+    ).inserted_primary_key
+
+    (rule_id,) = (
+        await db.execute(
+            sa.insert(models.rules).values(
+                name=None, action={"debug": None}, ruleset_id=ruleset_id
+            )
+        )
+    ).inserted_primary_key
+
+    (activation_instance_id,) = (
+        await db.execute(
+            sa.insert(models.activation_instances).values(
+                name="test-activation",
+                rulebook_id=rulebook_id,
+                inventory_id=inventory_id,
+                extra_var_id=extra_var_id,
+            )
+        )
+    ).inserted_primary_key
+
+    (job_instance_id,) = (
+        await db.execute(
+            sa.insert(models.job_instances).values(
+                uuid=TEST_AUDIT_RULE_JOB["uuid"],
+            )
+        )
+    ).inserted_primary_key
+
+    (job_instance_event_id,) = (
+        await db.execute(
+            sa.insert(models.job_instance_events).values(
+                job_uuid=TEST_AUDIT_RULE_JOB_EVENT["job_uuid"],
+                counter=TEST_AUDIT_RULE_JOB_EVENT["counter"],
+                type=TEST_AUDIT_RULE_JOB_EVENT["type"],
+                created_at=TEST_AUDIT_RULE_JOB_EVENT["created_at"],
+                stdout=TEST_AUDIT_RULE_JOB_EVENT["stdout"],
+            )
+        )
+    ).inserted_primary_key
+
+    (job_instance_host_id,) = (
+        await db.execute(
+            sa.insert(models.job_instance_hosts).values(
+                job_uuid=TEST_AUDIT_RULE_JOB_HOST["job_uuid"],
+                host=TEST_AUDIT_RULE_JOB_HOST["host"],
+                playbook=TEST_AUDIT_RULE_JOB_HOST["playbook"],
+                play=TEST_AUDIT_RULE_JOB_HOST["play"],
+                task=TEST_AUDIT_RULE_JOB_HOST["task"],
+                status=TEST_AUDIT_RULE_JOB_HOST["status"],
+            )
+        )
+    ).inserted_primary_key
+
+    foreign_keys = {
+        "extra_var_id": extra_var_id,
+        "inventory_id": inventory_id,
+        "rulebook_id": rulebook_id,
+        "ruleset_id": ruleset_id,
+        "rule_id": rule_id,
+        "activation_instance_id": activation_instance_id,
+        "job_instance_id": job_instance_id,
+        "job_instance_event_id": job_instance_event_id,
+        "job_instance_host_id": job_instance_host_id,
+    }
+
+    return foreign_keys
+
+
+async def _create_audit_rule(
+    client: AsyncClient, db: AsyncSession, foreign_keys
+):
+
+    (audit_rule_id,) = (
+        await db.execute(
+            sa.insert(models.audit_rules).values(
+                name=TEST_AUDIT_RULE["name"],
+                definition=TEST_AUDIT_RULE["definition"],
+                status=TEST_AUDIT_RULE["status"],
+                activation_instance_id=foreign_keys["activation_instance_id"],
+                ruleset_id=foreign_keys["ruleset_id"],
+                rule_id=foreign_keys["rule_id"],
+                job_instance_id=foreign_keys["job_instance_id"],
+                fired_date=datetime.datetime.now(),
+            )
+        )
+    ).inserted_primary_key
+
+    return audit_rule_id
+
+
+@pytest.mark.asyncio
+async def test_read_audit_rule_jobs(client: AsyncClient, db: AsyncSession):
+    foreign_keys = await _create_activation_dependent_objects(client, db)
+    audit_rule_id = await _create_audit_rule(client, db, foreign_keys)
+
+    audit_rules = (await db.execute(sa.select(models.audit_rules))).all()
+    assert len(audit_rules) == 1
+
+    response = await client.get(
+        f"/api/audit/rule/{audit_rule_id}/jobs",
+    )
+    audit_jobs = response.json()
+    assert response.status_code == status_codes.HTTP_200_OK
+    assert type(audit_jobs) == list
+    assert len(audit_jobs) == 1
+    job = audit_jobs[0]
+    assert job["id"] == foreign_keys["job_instance_id"]
+    assert job["status"] == TEST_AUDIT_RULE["status"]
+
+
+@pytest.mark.asyncio
+async def test_read_audit_details(client: AsyncClient, db: AsyncSession):
+    foreign_keys = await _create_activation_dependent_objects(client, db)
+    audit_rule_id = await _create_audit_rule(client, db, foreign_keys)
+    audit_rules = (await db.execute(sa.select(models.audit_rules))).all()
+    assert len(audit_rules) == 1
+
+    response = await client.get(
+        f"/api/audit/rule/{audit_rule_id}/details",
+    )
+    audit_rule = response.json()
+    assert response.status_code == status_codes.HTTP_200_OK
+    assert audit_rule["name"] == TEST_AUDIT_RULE["name"]
+    assert audit_rule["definition"] == TEST_AUDIT_RULE["definition"]
+    assert audit_rule["status"] == TEST_AUDIT_RULE["status"]
+    assert audit_rule["activation"] == {
+        "id": foreign_keys["activation_instance_id"],
+        "name": "test-activation",
+    }
+    assert audit_rule["ruleset"] == {
+        "id": foreign_keys["ruleset_id"],
+        "name": RULE_NAMES["ruleset_name"],
+    }
+    assert audit_rule["definition"] == TEST_AUDIT_RULE["definition"]
+
+
+@pytest.mark.asyncio
+async def test_read_audit_rule_events(client: AsyncClient, db: AsyncSession):
+    foreign_keys = await _create_activation_dependent_objects(client, db)
+    audit_rule_id = await _create_audit_rule(client, db, foreign_keys)
+    audit_rules = (await db.execute(sa.select(models.audit_rules))).all()
+    assert len(audit_rules) == 1
+
+    response = await client.get(
+        f"/api/audit/rule/{audit_rule_id}/events",
+    )
+    audit_job_events = response.json()
+    assert response.status_code == status_codes.HTTP_200_OK
+    assert type(audit_job_events) == list
+    assert len(audit_job_events) == 1
+    job_event = audit_job_events[0]
+    assert job_event["id"] == foreign_keys["job_instance_event_id"]
+    assert job_event["type"] == TEST_AUDIT_RULE_JOB_EVENT["type"]
+    assert (
+        job_event["increment_counter"] == TEST_AUDIT_RULE_JOB_EVENT["counter"]
+    )
+    assert job_event["name"] == TEST_AUDIT_RULE["name"]
+
+
+@pytest.mark.asyncio
+async def test_read_audit_rule_hosts(client: AsyncClient, db: AsyncSession):
+    foreign_keys = await _create_activation_dependent_objects(client, db)
+    audit_rule_id = await _create_audit_rule(client, db, foreign_keys)
+    audit_rules = (await db.execute(sa.select(models.audit_rules))).all()
+    assert len(audit_rules) == 1
+
+    response = await client.get(
+        f"/api/audit/rule/{audit_rule_id}/hosts",
+    )
+    audit_hosts = response.json()
+    assert response.status_code == status_codes.HTTP_200_OK
+    assert type(audit_hosts) == list
+    assert len(audit_hosts) == 1
+    host = audit_hosts[0]
+    assert host["id"] == foreign_keys["job_instance_host_id"]
+    assert host["name"] == TEST_AUDIT_RULE_JOB_HOST["host"]
+    assert host["status"] == TEST_AUDIT_RULE_JOB_HOST["status"]
+
+
+@pytest.mark.asyncio
+async def test_audit_rule_404(client: AsyncClient, db: AsyncSession):
+    audit_rule_id = 100
+    details_response = await client.get(
+        f"/api/audit/rule/{audit_rule_id}/details",
+    )
+    jobs_response = await client.get(
+        f"/api/audit/rule/{audit_rule_id}/jobs",
+    )
+    events_response = await client.get(
+        f"/api/audit/rule/{audit_rule_id}/events",
+    )
+    hosts_response = await client.get(
+        f"/api/audit/rule/{audit_rule_id}/hosts",
+    )
+    assert details_response.status_code == status_codes.HTTP_404_NOT_FOUND
+    assert jobs_response.status_code == status_codes.HTTP_404_NOT_FOUND
+    assert events_response.status_code == status_codes.HTTP_404_NOT_FOUND
+    assert hosts_response.status_code == status_codes.HTTP_404_NOT_FOUND

--- a/tests/integration/api/test_job.py
+++ b/tests/integration/api/test_job.py
@@ -43,13 +43,16 @@ async def test_create_delete_job(client: AsyncClient, db: AsyncSession):
     await db.execute(query)
 
     jobs = (await db.execute(sa.select(models.job_instances))).all()
-    assert len(jobs) == 1
+    jobs_len = len(jobs)
 
-    response = await client.delete("/api/job_instance/1")
+    job_to_delete = (await db.execute(sa.select(models.job_instances))).first()
+    job_id = job_to_delete.id
+
+    response = await client.delete(f"/api/job_instance/{job_id}")
     assert response.status_code == status_codes.HTTP_204_NO_CONTENT
 
     jobs = (await db.execute(sa.select(models.job_instances))).all()
-    assert len(jobs) == 0
+    assert len(jobs) == (jobs_len - 1)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Ticket [AAP-5230:](https://issues.redhat.com/browse/AAP-5458)
* adds API: /audit/rule/<:id>/jobs endpoint GET
* adds API: /audit/rule/<:id>/hosts endpoint GET
* adds API: /audit/rule/<:id>/events endpoint GET
* adds API: /audit/rule/<:id>/details endpoint GET

### Manual testing instructions 
#### Setup (there might be a better way to populate the audit rules for testing but this up but this is how I've been doing it)
1. Pull this branch and bring up the project 
2. Add a project (I used [https://github.com/benthomasson/eda-project](http://localhost:8080/eda/project/2) for testing) 
3. Add a rulebook activation
4. From the CLI run the following (or an equivalent if you don't have eda-project pulled locally): 
```
ansible-events --debug --rules ../eda-project/hello_events.yml -i ../eda-project/inventory.yml --websocket-address "ws://localhost:8080/api/ws2" --id 1
```
#### Test GET api/audit/rule/1/details
1. Verify that the audit rules table is populated in the db and get the ID (it should be 1 if you are starting fresh with testing)
2. Using postman or curl send a GET request to http://localhost:8080/api/audit/rule/1/details
3. Make sure that you see something like the following: 
```
{
    "name": "Say Hello",
    "description": null,
    "status": "successful",
    "activation": {
        "id": 1,
        "name": "test"
    },
    "ruleset": {
        "id": 2,
        "name": "Hello Events"
    },
    "created_at": "2022-09-26T19:19:43.679175+00:00",
    "fired_date": "2022-09-26T19:19:42.216395+00:00",
    "definition": {
        "run_playbook": {
            "name": "benthomasson.eda.hello"
        }
    }
}
```
4. Verify that using an audit rule ID that does not exist results in 404 http://localhost:8080/api/audit/rule/2/details
#### Test GET api/audit/rule/1/jobs
1. Verify that the audit rules table is populated in the db and get the ID (it should be 1 if you are starting fresh with testing)
2. Using postman or curl send a GET request to http://localhost:8080/api/audit/rule/1/jobs
3. Make sure that you see something like the following: 
```
[
    {
        "id": 1,
        "status": "successful",
        "last_fired_date": "2022-09-26T19:19:42.216395+00:00"
    }
]
```
4. Verify that using an audit rule ID that does not exist results in 404 http://localhost:8080/api/audit/rule/2/jobs
#### Test GET api/audit/rule/1/events
1. Verify that the audit rules table is populated in the db and get the ID (it should be 1 if you are starting fresh with testing)
2. Using postman or curl send a GET request to http://localhost:8080/api/audit/rule/1/events
3. Make sure that you see something like the following: 
```
[
    {
        "id": 1,
        "name": "Say Hello",
        "increment_counter": 1,
        "type": "playbook_on_start",
        "timestamp": "2022-09-26T23:19:43.373381+00:00"
    },
    {
        "id": 2,
        "name": "Say Hello",
        "increment_counter": 2,
        "type": "playbook_on_play_start",
        "timestamp": "2022-09-26T23:19:43.375731+00:00"
    },
    {
        "id": 3,
        "name": "Say Hello",
        "increment_counter": 3,
        "type": "playbook_on_task_start",
        "timestamp": "2022-09-26T23:19:43.408264+00:00"
    },
    {
        "id": 4,
        "name": "Say Hello",
        "increment_counter": 4,
        "type": "runner_on_start",
        "timestamp": "2022-09-26T23:19:43.409312+00:00"
    },
    {
        "id": 5,
        "name": "Say Hello",
        "increment_counter": 5,
        "type": "runner_on_ok",
        "timestamp": "2022-09-26T23:19:43.446861+00:00"
    },
    {
        "id": 6,
        "name": "Say Hello",
        "increment_counter": 6,
        "type": "playbook_on_stats",
        "timestamp": "2022-09-26T23:19:43.481408+00:00"
    }
]
```
4. Verify that using an audit rule ID that does not exist results in 404 http://localhost:8080/api/audit/rule/2/events
#### Test GET api/audit/rule/1/hosts
1. Verify that the audit rules table is populated in the db and get the ID (it should be 1 if you are starting fresh with testing)
2. Using postman or curl send a GET request to http://localhost:8080/api/audit/rule/1/hosts
3. Make sure that you see something like the following: 
```
[
    {
        "id": 1,
        "name": "localhost",
        "status": "ok"
    }
]
```
4. Verify that using an audit rule ID that does not exist results in 404 http://localhost:8080/api/audit/rule/2/hosts