### PR TITLE
Create GET Activations Endpoint

### DIFF
--- a/ansible_events_ui/api/activation.py
+++ b/ansible_events_ui/api/activation.py
@@ -78,7 +78,7 @@ async def create_activation(
 
 
 @router.get(
-    "/api/activation/{activation_id}",
+    "/api/activations/{activation_id}",
     response_model=schema.ActivationRead,
     operation_id="show_activation",
 )
@@ -168,7 +168,7 @@ async def list_activations(
 
 
 @router.patch(
-    "/api/activation/{activation_id}",
+    "/api/activations/{activation_id}",
     response_model=schema.ActivationBaseRead,
     operation_id="update_activation",
 )

--- a/tests/integration/api/test_activation.py
+++ b/tests/integration/api/test_activation.py
@@ -229,7 +229,7 @@ async def test_read_activation(client: AsyncClient, db: AsyncSession):
     activation_id = await _create_activation(client, db, foreign_keys)
 
     response = await client.get(
-        f"/api/activation/{activation_id}",
+        f"/api/activations/{activation_id}",
     )
     assert response.status_code == status_codes.HTTP_200_OK
     activation = response.json()
@@ -262,7 +262,7 @@ async def test_read_activation(client: AsyncClient, db: AsyncSession):
 
 @pytest.mark.asyncio
 async def test_read_activation_not_found(client: AsyncClient):
-    response = await client.get("/api/activation/1")
+    response = await client.get("/api/activations/1")
     assert response.status_code == status_codes.HTTP_404_NOT_FOUND
 
 
@@ -309,7 +309,7 @@ async def test_update_activation(client: AsyncClient, db: AsyncSession):
     }
 
     response = await client.patch(
-        f"/api/activation/{activation_id}",
+        f"/api/activations/{activation_id}",
         json=new_activation,
     )
     assert response.status_code == status_codes.HTTP_200_OK
@@ -330,7 +330,7 @@ async def test_update_activation_bad_entity(
     }
 
     response = await client.patch(
-        "/api/activation/1",
+        "/api/activations/1",
         json=new_activation,
     )
     assert response.status_code == status_codes.HTTP_422_UNPROCESSABLE_ENTITY
@@ -345,7 +345,7 @@ async def test_update_activation_not_found(client: AsyncClient):
     }
 
     response = await client.patch(
-        "/api/activation/1",
+        "/api/activations/1",
         json=new_activation,
     )
     assert response.status_code == status_codes.HTTP_404_NOT_FOUND


### PR DESCRIPTION
Create an API endpoint `/api/activations/` to list all activations.

**Testing Instructions**

Send a GET request to `http://localhost:8080/api/activations/` and verify that the response looks similar to the following:
```
[
    {
        "id": 1,
        "name": "test",
        "description": "demo activation",
        "status": null,
        "is_enabled": false,
        "working_directory": "/tmp",
        "execution_environment": "podman",
        "rulebook": {
            "id": 1,
            "name": "hello_events1k.yml"
        },
        "inventory": {
            "name": "ssh_inventory.yml",
            "id": 1
        },
        "extra_var": {
            "name": "vars.yml",
            "id": 1
        },
        "restart_policy": "always",
        "restarted_at": null,
        "restart_count": 0,
        "created_at": "2022-09-27T13:28:04.819202+00:00",
        "modified_at": "2022-09-27T13:28:04.819202+00:00"
    },
    ...
]
```

Resolves: AAP-5917