### PR TITLE
[AAP-6010] Add GH action to build automatically container images

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -1,0 +1,58 @@
+name: Build container images
+
+on:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  build-eda-server-image:
+    runs-on: ubuntu-latest
+    env:
+      EDA_TOKEN: ${{ secrets.EDA_SERVER_TOKEN }}
+      QUAY_PASSWORD: ${{ secrets.EDA_AIZQUIERDO_QUAY_PW }}
+      QUAY_USERNAME: "aizquier+edaci"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build image
+        run: |
+          export GITHUB_TOKEN=$EDA_TOKEN
+          docker build -t eda-server:latest -f tools/docker/Dockerfile . \
+          --no-cache --build-arg GITHUB_TOKEN=$GITHUB_TOKEN
+
+      - name: Tag image
+        run: >
+          docker image tag eda-server:latest
+          quay.io/aizquier/eda-server:latest
+
+      - name: Push image
+        run: |
+          docker login -u=$QUAY_USERNAME -p=$QUAY_PASSWORD quay.io
+          docker image push quay.io/aizquier/eda-server:latest
+
+  build-eda-server-ui-image:
+    runs-on: ubuntu-latest
+    env:
+      QUAY_PASSWORD: ${{ secrets.EDA_AIZQUIERDO_QUAY_PW }}
+      QUAY_USERNAME: "aizquier+edaci"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build image
+        run: >
+          docker build -t eda-server-ui:latest 
+          -f tools/docker/nginx/Dockerfile
+          --no-cache .
+
+      - name: Tag image
+        run: >
+          docker image tag eda-server-ui:latest
+          quay.io/aizquier/eda-server-ui:latest
+
+      - name: Push image
+        run: |
+          docker login -u=$QUAY_USERNAME -p=$QUAY_PASSWORD quay.io
+          docker image push quay.io/aizquier/eda-server-ui:latest


### PR DESCRIPTION
Add GH action to build automatically the container image from the main branch on: `quay.io/aizquier/eda-server:latest` and `quay.io/aizquier/eda-server-ui:latest`

Closes https://issues.redhat.com/browse/AAP-6010

Note that the image is public. Create a private repository in quay.io requires a developer plan (I'm trying to acquire it)
Also quay.io supports the automatic build from the repository without need any GH action, but doesn't support build-args required to inject the token for the private repos, that's why use an action. When the repository becomes public, can be changed.