### PR TITLE
Fix cross join in ruleset query

### DIFF
--- a/ansible_events_ui/api/rulebook.py
+++ b/ansible_events_ui/api/rulebook.py
@@ -105,12 +105,6 @@ rule_count_lateral = (
 )
 ruls_ct = sa.orm.aliased(rule_count_lateral)
 
-# There is a possibility that this may generate a SQLAlchemy warning,
-# but all of the reference links are safe and the database does not
-# throw an error or warning.
-# Thre is a reported fix, but it may not be released at the time of this
-# coding.
-# See: https://github.com/sqlalchemy/sqlalchemy/issues/7507
 BASE_RULESET_SELECT = (
     sa.select(
         ruleset.c.id,
@@ -157,7 +151,7 @@ async def list_rulesets(db: AsyncSession = Depends(get_db_session)):
 async def get_ruleset(
     ruleset_id: int, db: AsyncSession = Depends(get_db_session)
 ):
-    query = BASE_RULESET_SELECT.filter(models.rulesets.c.id == ruleset_id)
+    query = BASE_RULESET_SELECT.filter(ruleset.c.id == ruleset_id)
     rec = (await db.execute(query)).first()
     if not rec:
         raise HTTPException(


### PR DESCRIPTION
This patch fixes cross join created in ruleset query by using SQLAlchemy aliases:

```
SELECT ruleset_1.id,
       ruleset_1.name,
       ruleset_1.created_at,
       ruleset_1.modified_at,
       coalesce(anon_1.rule_count, 0)                         AS rule_count,
       coalesce(jsonb_build_object('id', rulebook_1.id, 'name', rulebook_1.name),
                jsonb_build_object('id', NULL, 'name', NULL)) AS rulebook,
       coalesce(jsonb_build_object('id', project_1.id, 'name', project_1.name),
                jsonb_build_object('id', NULL, 'name', NULL)) AS project
FROM ruleset,
     ruleset AS ruleset_1
         LEFT OUTER JOIN rulebook AS rulebook_1 ON rulebook_1.id = ruleset_1.rulebook_id
         LEFT OUTER JOIN project AS project_1 ON project_1.id = rulebook_1.project_id
         LEFT OUTER JOIN LATERAL (SELECT count(rule_1.id) AS rule_count
                                  FROM rule AS rule_1
                                  WHERE rule_1.ruleset_id = ruleset_1.id) AS anon_1 ON true
WHERE ruleset.id = 1
```