### PR TITLE
Fix to handle host:port in headers for rediects

### DIFF
--- a/tools/docker/nginx/default.conf
+++ b/tools/docker/nginx/default.conf
@@ -8,7 +8,7 @@ server {
         proxy_pass http://eda-server:9000;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Port $server_port;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
         proxy_http_version 1.1;
@@ -18,7 +18,7 @@ server {
 
     location ~ ^/(api|ping)/ {
         proxy_pass http://eda-server:9000;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Port $server_port;


### PR DESCRIPTION
[[AAP-6058](https://issues.redhat.com/browse/AAP-6058)] - support host:port in headers when redirect

Testing
```
> curl -v http://localhost:8080/api/rulebooks/
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /api/rulebooks/ HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.79.1
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 307 Temporary Redirect
< Server: nginx
< Date: Wed, 28 Sep 2022 18:16:42 GMT
< Content-Length: 0
< Connection: keep-alive
< location: http://localhost:8080/api/rulebooks.  <-------------- You will not see port in current main branch
< 
* Connection #0 to host localhost left intact
```