### PR TITLE
fix swagger view for enums

### DIFF
--- a/ansible_events_ui/db/models/activation.py
+++ b/ansible_events_ui/db/models/activation.py
@@ -13,13 +13,13 @@ __all__ = (
 )
 
 
-class RestartPolicy(Enum):
+class RestartPolicy(str, Enum):
     ALWAYS = "always"
     ON_FAILURE = "on-failure"
     NEVER = "never"
 
 
-class ExecutionEnvironment(Enum):
+class ExecutionEnvironment(str, Enum):
     DOCKER = "docker"
     PODMAN = "podman"
     K8S = "k8s"


### PR DESCRIPTION
Enum must inherit from string to enforce the type in the openapi spec and be able to see the options in swagger
![Screenshot from 2022-09-29 12-44-46](https://user-images.githubusercontent.com/86774347/193011779-cb31e0fc-f97c-4846-8d24-c620ae72295e.png)
