### PR TITLE
Use editable install in docker environment

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -16,7 +16,7 @@ COPY . $WORKDIR
 RUN chown -R $USER_ID ./
 
 USER $USER_ID
-RUN pip install .
+RUN pip install -e .
 
 RUN bash -c "if [ $DEVEL_AE_LIBRARY -ne 0 ]; then \
     pip uninstall ansible-events -y && \


### PR DESCRIPTION
Install the project in "editable" mode when building docker image.

Installing package as a regular one bulds a distribution which installed in system directories. This results in two copies of the package (source tree copied into image and installed distribution).

Additionally due to a bug in distribution build scripts, the package data is not installed properly, which is going to be fixed in another patch.