### PR TITLE
[AAP-5473] rulebook list updates

### DIFF
--- a/src/eda_server/schema/rulebook.py
+++ b/src/eda_server/schema/rulebook.py
@@ -20,14 +20,17 @@ class RulebookRead(BaseModel):
     modified_at: datetime
 
 
-class RulebookList(RulebookCreate):
-    id: int
-
-
 class RulebookRulesetList(BaseModel):
     id: int
     name: StrictStr
     rule_count: int
+    fire_count: int
+
+
+class RulebookList(BaseModel):
+    id: int
+    name: StrictStr
+    ruleset_count: int
     fire_count: int
 
 


### PR DESCRIPTION
**AAP-5473:**
- Features Added:
  - Matching list rulebooks endpoint return to the information needed in the mocks which would be name, number of rulesets, fire count, and id

Jira Ticket: [AAP-5473](https://issues.redhat.com/browse/AAP-5473)

**Testing Instructions:**
1. Create project I utilize https://github.com/benthomasson/eda-project
2. Create Rulebook activation 
3. Run the following command with appropriate information to populate the audit rule table
`ansible-events --debug --rules ../eda-project/hello_events.yml -i ../eda-project/inventory.yml --websocket-address "ws://localhost:8080/api/ws2" --id 1`
4. Insure the audit rules table is populated in the DB
5. Test rulebooks list page GET-http://localhost:9000/api/rulebooks/ which should have the following return format
```
[
    {
        "id": 2,
        "name": "Hello Events",
        "rule_count": 0,
        "fire_count": 2
    }
]
```
