### PR TITLE
Continue refactoring of the project sync service

### DIFF
--- a/src/eda_server/api/rulebook.py
+++ b/src/eda_server/api/rulebook.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from eda_server import schema
 from eda_server.db import models
 from eda_server.db.dependency import get_db_session
-from eda_server.project import insert_rulebook_related_data
+from eda_server.project import create_rules
 
 router = APIRouter(tags=["rulebooks"])
 
@@ -214,7 +214,7 @@ async def create_rulebook(
     (id_,) = result.inserted_primary_key
 
     rulebook_data = yaml.safe_load(rulebook.rulesets)
-    await insert_rulebook_related_data(db, id_, rulebook_data)
+    await create_rules(db, id_, rulebook_data)
     await db.commit()
 
     return {**rulebook.dict(), "id": id_}

--- a/tests/integration/api/test_project.py
+++ b/tests/integration/api/test_project.py
@@ -123,7 +123,9 @@ async def test_delete_project_not_found(client: AsyncClient):
 @mock.patch("tempfile.TemporaryDirectory")
 @mock.patch("eda_server.project.clone_project")
 @mock.patch("eda_server.project.sync_project")
+@mock.patch("eda_server.project.tar_project")
 async def test_create_project(
+    tar_project: mock.Mock,
     sync_project: mock.Mock,
     clone_project: mock.Mock,
     tempfile: mock.Mock(),
@@ -152,7 +154,10 @@ async def test_create_project(
 
     clone_project.assert_called_once_with(TEST_PROJECT["url"], mock.ANY)
     sync_project.assert_called_once_with(
-        db, project["id"], project["large_data_id"], "/tmp/test-create-project"
+        db, project["id"], "/tmp/test-create-project"
+    )
+    tar_project.assert_called_once_with(
+        db, project["large_data_id"], "/tmp/test-create-project"
     )
 
 


### PR DESCRIPTION
Changes made:

1. The project files scanning was reworked (preserving the original
   behavior).

   Previous implementation was iterating over project files and
   reading the files multiple times. The directory tree was scanned
   4 times, once per each content type (rulebook, inventory,
   playbook and extra vars).

   New implementation iterates over project files only once. Each
   file is opened and readed only once as well.

2. This allowed to structure the project synchronization better.
   With duplicated code that iterated over the project file being stripped,
   the functions responsible for insertion of files of a specific type
   became pure database query functions, that allows moving them into
   isolated layer in the following update.

3. Use shallow clone (`git clone --depth 1`) of the project repository
   to avoid unnecessary downloading of a project commit history.

4. Archive repository with `git archive` command instead of `tar` to
   store only files tracked by git and not the `.git` repository itself.