### PR TITLE
[AAP-5245] Improve test coverage for APIs permission checking

### DIFF
--- a/src/eda_server/api/activation.py
+++ b/src/eda_server/api/activation.py
@@ -502,7 +502,10 @@ async def stream_activation_instance_logs(
     )
     activation_instance = (await db.execute(query)).first()
     if activation_instance is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Activation instance Not Found.",
+        )
 
     large_data_id = activation_instance.large_data_id
 

--- a/src/eda_server/api/job.py
+++ b/src/eda_server/api/job.py
@@ -256,8 +256,15 @@ async def read_job_instance(
             models.audit_rules.c.job_instance_id == models.job_instances.c.id,
         )
     ).where(models.job_instances.c.id == job_instance_id)
-    result = await db.execute(query)
-    return result.first()
+    job_instance = (await db.execute(query)).first()
+
+    if job_instance is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Job instance Not Found.",
+        )
+
+    return job_instance
 
 
 @router.delete(
@@ -293,6 +300,12 @@ async def read_job_instance_events(
         models.job_instances.c.id == job_instance_id
     )
     job = (await db.execute(query)).first()
+
+    if job is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Job instance Not Found.",
+        )
 
     query = (
         sa.select(models.job_instance_events)

--- a/tests/integration/api/test_activation.py
+++ b/tests/integration/api/test_activation.py
@@ -472,7 +472,7 @@ async def _create_activation_instance(db: AsyncSession, foreign_keys: dict):
     return activation_instance_id
 
 
-@mock.patch("eda_server.ruleset.activate_rulesets")
+@mock.patch("eda_server.ruleset.activate_rulesets", return_value=mock.ANY)
 async def test_create_activation_instance(
     activate_rulesets: mock.Mock,
     client: AsyncClient,

--- a/tests/integration/api/test_extra_vars.py
+++ b/tests/integration/api/test_extra_vars.py
@@ -11,9 +11,164 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+from unittest import mock
 
+import sqlalchemy as sa
 from fastapi import status as status_codes
 from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from eda_server.db import models
+from eda_server.db.sql import base as bsql
+from eda_server.types import Action, ResourceType
+
+TEST_PROJECT = {
+    "url": "https://git.example.com/sample/test-project",
+    "name": "Test Name",
+    "description": "This is a test description",
+}
+
+TEST_EXTRA_VAR = """
+---
+collections:
+  - community.general
+  - benthomasson.eda  # 1.3.0
+"""
+
+
+async def _create_dependent_project(db: AsyncSession):
+    (project_id,) = (
+        await bsql.insert_object(
+            db,
+            models.projects,
+            values=TEST_PROJECT,
+        )
+    ).inserted_primary_key
+
+    return project_id
+
+
+async def _create_extra_var(db: AsyncSession):
+    project_id = await _create_dependent_project(db)
+
+    (extra_var_id,) = (
+        await bsql.insert_object(
+            db,
+            models.extra_vars,
+            values={
+                "name": "test_extra_var",
+                "extra_var": TEST_EXTRA_VAR,
+                "project_id": project_id,
+            },
+        )
+    ).inserted_primary_key
+
+    return {"project_id": project_id, "extra_var_id": extra_var_id}
+
+
+async def test_create_extar_var(
+    client: AsyncClient, db: AsyncSession, check_permission_spy: mock.Mock
+):
+    project_id = await _create_dependent_project(db)
+    await db.commit()
+
+    response = await client.post(
+        "/api/extra_vars/",
+        json={
+            "name": "test_create_extar_var",
+            "extra_var": TEST_EXTRA_VAR,
+            "project_id": project_id,
+        },
+    )
+    assert response.status_code == status_codes.HTTP_200_OK
+    data = response.json()
+    assert data["name"] == "test_create_extar_var"
+    assert data["extra_var"] == TEST_EXTRA_VAR
+
+    extra_vars = (await db.execute(sa.select(models.extra_vars))).all()
+    assert len(extra_vars) == 1
+    extra_var = extra_vars[0]
+    assert extra_var["extra_var"] == TEST_EXTRA_VAR
+
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.EXTRA_VAR, Action.CREATE
+    )
+
+
+async def test_create_extar_var_bad_entity(
+    client: AsyncClient, check_permission_spy: mock.Mock
+):
+    response = await client.post(
+        "/api/extra_vars/",
+        json=TEST_EXTRA_VAR,
+    )
+    assert response.status_code == status_codes.HTTP_422_UNPROCESSABLE_ENTITY
+
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.EXTRA_VAR, Action.CREATE
+    )
+
+
+async def test_list_extra_vars(
+    client: AsyncClient, db: AsyncSession, check_permission_spy: mock.Mock
+):
+    fks = await _create_extra_var(db)
+    await db.commit()
+
+    response = await client.get(
+        "/api/extra_vars/",
+    )
+    assert response.status_code == status_codes.HTTP_200_OK
+    extra_vars = response.json()
+    assert type(extra_vars) is list
+    assert len(extra_vars) > 0
+
+    extra_var = extra_vars[0]
+    assert extra_var["id"] == fks["extra_var_id"]
+    assert extra_var["name"] == "test_extra_var"
+    assert extra_var["extra_var"] == TEST_EXTRA_VAR
+
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.EXTRA_VAR, Action.READ
+    )
+
+
+async def test_list_extra_vars_empty_response(
+    client: AsyncClient, check_permission_spy: mock.Mock
+):
+    response = await client.get(
+        "/api/extra_vars/",
+    )
+    assert response.status_code == status_codes.HTTP_200_OK
+    extra_vars = response.json()
+    assert extra_vars == []
+
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.EXTRA_VAR, Action.READ
+    )
+
+
+async def test_read_extra_vars(
+    client: AsyncClient, db: AsyncSession, check_permission_spy: mock.Mock
+):
+    fks = await _create_extra_var(db)
+    await db.commit()
+
+    extra_var_id = fks["extra_var_id"]
+    response = await client.get(
+        f"/api/extra_var/{extra_var_id}",
+    )
+
+    assert response.status_code == status_codes.HTTP_200_OK
+    extra_var = response.json()
+    assert "id" in extra_var
+
+    assert extra_var["name"] == "test_extra_var"
+    assert extra_var["extra_var"] == TEST_EXTRA_VAR
+
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.EXTRA_VAR, Action.READ
+    )
 
 
 async def test_read_extra_var_not_found(client: AsyncClient):

--- a/tests/integration/api/test_extra_vars.py
+++ b/tests/integration/api/test_extra_vars.py
@@ -73,14 +73,14 @@ async def test_create_extar_var(
     await db.commit()
 
     response = await client.post(
-        "/api/extra_vars/",
+        "/api/extra_vars",
         json={
             "name": "test_create_extar_var",
             "extra_var": TEST_EXTRA_VAR,
             "project_id": project_id,
         },
     )
-    assert response.status_code == status_codes.HTTP_200_OK
+    assert response.status_code == status_codes.HTTP_201_CREATED
     data = response.json()
     assert data["name"] == "test_create_extar_var"
     assert data["extra_var"] == TEST_EXTRA_VAR
@@ -99,7 +99,7 @@ async def test_create_extar_var_bad_entity(
     client: AsyncClient, check_permission_spy: mock.Mock
 ):
     response = await client.post(
-        "/api/extra_vars/",
+        "/api/extra_vars",
         json=TEST_EXTRA_VAR,
     )
     assert response.status_code == status_codes.HTTP_422_UNPROCESSABLE_ENTITY
@@ -116,7 +116,7 @@ async def test_list_extra_vars(
     await db.commit()
 
     response = await client.get(
-        "/api/extra_vars/",
+        "/api/extra_vars",
     )
     assert response.status_code == status_codes.HTTP_200_OK
     extra_vars = response.json()
@@ -137,7 +137,7 @@ async def test_list_extra_vars_empty_response(
     client: AsyncClient, check_permission_spy: mock.Mock
 ):
     response = await client.get(
-        "/api/extra_vars/",
+        "/api/extra_vars",
     )
     assert response.status_code == status_codes.HTTP_200_OK
     extra_vars = response.json()

--- a/tests/integration/api/test_playbook.py
+++ b/tests/integration/api/test_playbook.py
@@ -13,11 +13,132 @@
 #  limitations under the License.
 
 # TODO(cutwater): Add unit tests for API endpoints
+from unittest import mock
+
 from fastapi import status as status_codes
 from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from eda_server.db import models
+from eda_server.db.sql import base as bsql
+from eda_server.types import Action, ResourceType
+
+TEST_PROJECT = {
+    "url": "https://git.example.com/sample/test-project",
+    "name": "Test Name",
+    "description": "This is a test description",
+}
 
 
-async def test_read_playbook_not_found(client: AsyncClient):
+TEST_PLAYBOOK = """
+---
+- name: hello
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - debug:
+        msg: hello
+"""
+
+
+async def _create_playbooks(db: AsyncSession):
+    (project_id,) = (
+        await bsql.insert_object(
+            db,
+            models.projects,
+            values=TEST_PROJECT,
+        )
+    ).inserted_primary_key
+
+    (playbook_id,) = (
+        await bsql.insert_object(
+            db,
+            models.playbooks,
+            values={
+                "name": "hello.yml",
+                "playbook": TEST_PLAYBOOK,
+                "project_id": project_id,
+            },
+        )
+    ).inserted_primary_key
+
+    foreign_keys = {
+        "project_id": project_id,
+        "playbook_id": playbook_id,
+    }
+
+    return foreign_keys
+
+
+async def test_list_playbooks(
+    client: AsyncClient, db: AsyncSession, check_permission_spy: mock.Mock
+):
+    fks = await _create_playbooks(db)
+    await db.commit()
+
+    response = await client.get(
+        "/api/playbooks/",
+    )
+    assert response.status_code == status_codes.HTTP_200_OK
+    playbooks = response.json()
+    assert type(playbooks) is list
+    assert len(playbooks) > 0
+
+    playbook = playbooks[0]
+    assert playbook["id"] == fks["playbook_id"]
+    assert playbook["name"] == "hello.yml"
+    assert playbook["project_id"] == fks["project_id"]
+
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.PLAYBOOK, Action.READ
+    )
+
+
+async def test_list_playbooks_empty_response(
+    client: AsyncClient, check_permission_spy: mock.Mock
+):
+    response = await client.get(
+        "/api/playbooks/",
+    )
+    assert response.status_code == status_codes.HTTP_200_OK
+    activations = response.json()
+    assert activations == []
+
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.PLAYBOOK, Action.READ
+    )
+
+
+async def test_read_playbook(
+    client: AsyncClient, db: AsyncSession, check_permission_spy: mock.Mock
+):
+    fks = await _create_playbooks(db)
+    await db.commit()
+
+    playbook_id = fks["playbook_id"]
+    response = await client.get(
+        f"/api/playbook/{playbook_id}",
+    )
+    assert response.status_code == status_codes.HTTP_200_OK
+    playbook = response.json()
+    assert "id" in playbook
+
+    assert playbook["name"] == "hello.yml"
+    assert playbook["id"] == fks["playbook_id"]
+    assert playbook["project_id"] == fks["project_id"]
+
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.PLAYBOOK, Action.READ
+    )
+
+
+async def test_read_playbook_not_found(
+    client: AsyncClient, check_permission_spy: mock.Mock
+):
     response = await client.get("/api/playbook/42")
 
     assert response.status_code == status_codes.HTTP_404_NOT_FOUND
+
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.PLAYBOOK, Action.READ
+    )

--- a/tests/integration/api/test_playbook.py
+++ b/tests/integration/api/test_playbook.py
@@ -77,7 +77,7 @@ async def test_list_playbooks(
     await db.commit()
 
     response = await client.get(
-        "/api/playbooks/",
+        "/api/playbooks",
     )
     assert response.status_code == status_codes.HTTP_200_OK
     playbooks = response.json()
@@ -98,7 +98,7 @@ async def test_list_playbooks_empty_response(
     client: AsyncClient, check_permission_spy: mock.Mock
 ):
     response = await client.get(
-        "/api/playbooks/",
+        "/api/playbooks",
     )
     assert response.status_code == status_codes.HTTP_200_OK
     activations = response.json()

--- a/tests/integration/api/test_role.py
+++ b/tests/integration/api/test_role.py
@@ -128,6 +128,42 @@ async def test_show_role_not_exist(client: AsyncClient):
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
+async def test_list_role(
+    client: AsyncClient, db: AsyncSession, check_permission_spy: mock.Mock
+):
+    role_id = await create_role(db, "test-role-08")
+    await db.commit()
+
+    response = await client.get("/api/roles")
+    assert response.status_code == status.HTTP_200_OK
+    roles = response.json()
+    assert type(roles) is list
+    assert len(roles) > 0
+
+    role = roles[0]
+    assert role["id"] == f"{role_id}"
+    assert role["name"] == "test-role-08"
+
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.ROLE, Action.READ
+    )
+
+
+async def test_list_roles_empty_response(
+    client: AsyncClient, check_permission_spy: mock.Mock
+):
+    response = await client.get(
+        "/api/roles",
+    )
+    assert response.status_code == status.HTTP_200_OK
+    roles = response.json()
+    assert roles == []
+
+    check_permission_spy.assert_called_once_with(
+        mock.ANY, mock.ANY, ResourceType.ROLE, Action.READ
+    )
+
+
 async def test_delete_role(
     client: AsyncClient, db: AsyncSession, check_permission_spy: mock.Mock
 ):

--- a/tests/integration/api/test_task.py
+++ b/tests/integration/api/test_task.py
@@ -1,0 +1,37 @@
+#  Copyright 2022 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from unittest import mock
+
+from fastapi import status as status_codes
+from httpx import AsyncClient
+
+from eda_server.types import Action, ResourceType
+
+
+async def test_list_tasks(
+    client: AsyncClient,
+    check_permission_spy: mock.Mock,
+):
+    response = await client.get(
+        "/api/tasks",
+    )
+    assert response.status_code == status_codes.HTTP_200_OK
+    tasks = response.json()
+
+    assert tasks == []
+
+    check_permission_spy.assert_called_with(
+        mock.ANY, mock.ANY, ResourceType.TASK, Action.READ
+    )


### PR DESCRIPTION
Add more test cases for permission checks on the endpoints of `Action Instance`, `Extra Var`, `Playbook`, `Role`, `Job`, `Task` and `Rulebook`.

Resolves: [AAP-5245](https://issues.redhat.com/browse/AAP-5245)